### PR TITLE
feat: trainer client list and progress views (#47, #49)

### DIFF
--- a/lib/gym_studio_web/live/trainer/client_goals_live.ex
+++ b/lib/gym_studio_web/live/trainer/client_goals_live.ex
@@ -1,0 +1,139 @@
+defmodule GymStudioWeb.Trainer.ClientGoalsLive do
+  @moduledoc """
+  Trainer read-only view of a client's fitness goals and progress bars.
+  Reuses logic from `GymStudio.Goals`.
+  """
+  use GymStudioWeb, :live_view
+
+  alias GymStudio.{Accounts, Goals, Scheduling}
+
+  @impl true
+  def mount(%{"client_id" => client_id}, _session, socket) do
+    trainer = socket.assigns.current_scope.user
+
+    if Scheduling.trainer_has_client?(trainer.id, client_id) do
+      client = Accounts.get_user!(client_id)
+      goals = Goals.list_goals(client_id)
+
+      socket =
+        socket
+        |> assign(page_title: "#{client.name || "Client"}'s Goals")
+        |> assign(client: client)
+        |> assign(goals: goals)
+        |> assign(status_filter: "all")
+
+      {:ok, socket}
+    else
+      socket =
+        socket
+        |> put_flash(:error, "Not authorized to view this client's goals.")
+        |> redirect(to: ~p"/trainer/clients")
+
+      {:ok, socket}
+    end
+  end
+
+  @impl true
+  def handle_event("filter_status", %{"status" => status}, socket) do
+    client_id = socket.assigns.client.id
+    opts = if status in [nil, "", "all"], do: [], else: [status: status]
+    goals = Goals.list_goals(client_id, opts)
+    {:noreply, assign(socket, goals: goals, status_filter: status)}
+  end
+
+  defp progress_percent(current, target) do
+    if Decimal.compare(target, Decimal.new(0)) == :gt do
+      current
+      |> Decimal.mult(100)
+      |> Decimal.div(target)
+      |> Decimal.round(0)
+      |> Decimal.to_integer()
+      |> min(100)
+    else
+      0
+    end
+  end
+
+  defp status_badge_class("active"), do: "badge badge-info"
+  defp status_badge_class("achieved"), do: "badge badge-success"
+  defp status_badge_class("abandoned"), do: "badge badge-ghost"
+  defp status_badge_class(_), do: "badge"
+
+  defp status_label("active"), do: "Active"
+  defp status_label("achieved"), do: "🏆 Achieved"
+  defp status_label("abandoned"), do: "Abandoned"
+  defp status_label(s), do: s
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <div class="min-h-screen bg-gray-100 py-8">
+      <div class="container mx-auto px-4">
+        <div class="mb-6">
+          <.link
+            navigate={~p"/trainer/clients/#{@client.id}/progress"}
+            class="btn btn-ghost btn-sm mb-2"
+          >
+            ← Back to Progress
+          </.link>
+          <h1 class="text-2xl md:text-3xl font-bold text-gray-800">
+            {@client.name || "Client"}'s Goals
+          </h1>
+          <p class="text-gray-600 mt-1">Fitness goals and progress</p>
+        </div>
+
+        <%!-- Status Filter --%>
+        <div class="mb-6">
+          <form phx-change="filter_status">
+            <select name="status" class="select select-bordered w-full max-w-xs">
+              <option value="all" selected={@status_filter == "all"}>All Goals</option>
+              <option value="active" selected={@status_filter == "active"}>Active</option>
+              <option value="achieved" selected={@status_filter == "achieved"}>Achieved</option>
+              <option value="abandoned" selected={@status_filter == "abandoned"}>Abandoned</option>
+            </select>
+          </form>
+        </div>
+
+        <%!-- Goal Cards --%>
+        <%= if @goals == [] do %>
+          <div class="bg-white rounded-2xl shadow-lg p-8 text-center">
+            <p class="text-gray-500 text-lg">No goals yet.</p>
+          </div>
+        <% else %>
+          <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+            <%= for goal <- @goals do %>
+              <div class="bg-white rounded-2xl shadow-lg p-6">
+                <div class="flex justify-between items-start mb-3">
+                  <h3 class="text-lg font-semibold text-gray-800">{goal.title}</h3>
+                  <span class={status_badge_class(goal.status)}>{status_label(goal.status)}</span>
+                </div>
+
+                <%= if goal.description do %>
+                  <p class="text-gray-500 text-sm mb-3">{goal.description}</p>
+                <% end %>
+
+                <div class="mb-3">
+                  <div class="flex justify-between text-sm text-gray-600 mb-1">
+                    <span>{goal.current_value} / {goal.target_value} {goal.target_unit}</span>
+                    <span>{progress_percent(goal.current_value, goal.target_value)}%</span>
+                  </div>
+                  <progress
+                    class="progress progress-primary w-full"
+                    value={progress_percent(goal.current_value, goal.target_value)}
+                    max="100"
+                  >
+                  </progress>
+                </div>
+
+                <%= if goal.target_date do %>
+                  <p class="text-xs text-gray-400">Target: {goal.target_date}</p>
+                <% end %>
+              </div>
+            <% end %>
+          </div>
+        <% end %>
+      </div>
+    </div>
+    """
+  end
+end

--- a/lib/gym_studio_web/live/trainer/client_list_live.ex
+++ b/lib/gym_studio_web/live/trainer/client_list_live.ex
@@ -1,0 +1,97 @@
+defmodule GymStudioWeb.Trainer.ClientListLive do
+  @moduledoc """
+  Trainer client list page — shows all unique clients the trainer has sessions with.
+  Supports search by client name.
+  """
+  use GymStudioWeb, :live_view
+
+  alias GymStudio.Scheduling
+
+  @impl true
+  def mount(_params, _session, socket) do
+    user = socket.assigns.current_scope.user
+    clients = Scheduling.list_trainer_clients(user.id)
+
+    socket =
+      socket
+      |> assign(page_title: "My Clients")
+      |> assign(clients: clients)
+      |> assign(search: "")
+
+    {:ok, socket}
+  end
+
+  @impl true
+  def handle_event("search", %{"search" => search}, socket) do
+    user = socket.assigns.current_scope.user
+    clients = Scheduling.list_trainer_clients(user.id, search: search)
+    {:noreply, assign(socket, clients: clients, search: search)}
+  end
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <div class="min-h-screen bg-gray-100 py-8">
+      <div class="container mx-auto px-4">
+        <div class="mb-6">
+          <h1 class="text-2xl md:text-3xl font-bold text-gray-800">My Clients</h1>
+          <p class="text-gray-600 mt-1">Clients you've trained with</p>
+        </div>
+
+        <%!-- Search --%>
+        <div class="mb-6">
+          <form phx-change="search">
+            <input
+              type="text"
+              name="search"
+              value={@search}
+              placeholder="Search by client name..."
+              class="input input-bordered w-full max-w-xs"
+              phx-debounce="300"
+            />
+          </form>
+        </div>
+
+        <%!-- Client Cards --%>
+        <%= if @clients == [] do %>
+          <div class="bg-white rounded-2xl shadow-lg p-8 text-center">
+            <p class="text-gray-500 text-lg">No clients found.</p>
+            <p class="text-gray-400 mt-2">
+              <%= if @search != "" do %>
+                No clients match your search.
+              <% else %>
+                You'll see clients here once you have training sessions.
+              <% end %>
+            </p>
+          </div>
+        <% else %>
+          <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+            <%= for client <- @clients do %>
+              <div class="bg-white rounded-2xl shadow-lg p-5">
+                <h3 class="font-semibold text-lg text-gray-800 mb-2">
+                  {client.name || client.email || "Unknown"}
+                </h3>
+                <div class="space-y-1 text-sm text-gray-600 mb-4">
+                  <p>Total sessions: <span class="font-medium">{client.total_sessions}</span></p>
+                  <p>
+                    Last session:
+                    <span class="font-medium">
+                      {Calendar.strftime(client.last_session_date, "%b %d, %Y")}
+                    </span>
+                  </p>
+                </div>
+                <.link
+                  navigate={~p"/trainer/clients/#{client.user_id}/progress"}
+                  class="btn btn-primary btn-sm"
+                >
+                  View Progress →
+                </.link>
+              </div>
+            <% end %>
+          </div>
+        <% end %>
+      </div>
+    </div>
+    """
+  end
+end

--- a/lib/gym_studio_web/live/trainer/client_metrics_live.ex
+++ b/lib/gym_studio_web/live/trainer/client_metrics_live.ex
@@ -1,0 +1,121 @@
+defmodule GymStudioWeb.Trainer.ClientMetricsLive do
+  @moduledoc """
+  Trainer read-only view of a client's body metrics and weight chart.
+  Reuses logic from `GymStudio.Metrics`.
+  """
+  use GymStudioWeb, :live_view
+
+  alias GymStudio.{Accounts, Metrics, Scheduling}
+
+  @impl true
+  def mount(%{"client_id" => client_id}, _session, socket) do
+    trainer = socket.assigns.current_scope.user
+
+    if Scheduling.trainer_has_client?(trainer.id, client_id) do
+      client = Accounts.get_user!(client_id)
+      metrics = Metrics.list_metrics(client_id)
+      chart_data = build_weight_chart_data(client_id)
+
+      socket =
+        socket
+        |> assign(page_title: "#{client.name || "Client"}'s Body Metrics")
+        |> assign(client: client)
+        |> assign(metrics: metrics)
+        |> assign(chart_data: chart_data)
+
+      {:ok, socket}
+    else
+      socket =
+        socket
+        |> put_flash(:error, "Not authorized to view this client's metrics.")
+        |> redirect(to: ~p"/trainer/clients")
+
+      {:ok, socket}
+    end
+  end
+
+  defp build_weight_chart_data(user_id) do
+    history = Metrics.get_metric_history(user_id, :weight_kg)
+    labels = Enum.map(history, fn {date, _} -> Date.to_string(date) end)
+
+    values =
+      Enum.map(history, fn {_, value} -> Decimal.to_float(value) end)
+
+    Jason.encode!(%{labels: labels, values: values, y_label: "Weight (kg)"})
+  end
+
+  defp format_decimal(nil), do: "—"
+  defp format_decimal(val), do: Decimal.to_string(val)
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <div class="min-h-screen bg-gray-100 py-8">
+      <div class="container mx-auto px-4">
+        <div class="mb-6 flex items-center gap-4">
+          <.link navigate={~p"/trainer/clients/#{@client.id}/progress"} class="btn btn-ghost btn-sm">
+            ← Back to Progress
+          </.link>
+          <div>
+            <h1 class="text-2xl md:text-3xl font-bold text-gray-800">
+              {@client.name || "Client"}'s Body Metrics
+            </h1>
+            <p class="text-gray-600 mt-1">Weight, body fat, and measurements</p>
+          </div>
+        </div>
+
+        <%!-- Weight Chart --%>
+        <%= if @metrics != [] and Enum.any?(@metrics, & &1.weight_kg) do %>
+          <div class="bg-white rounded-2xl shadow-lg p-6 mb-6">
+            <h2 class="text-lg font-semibold mb-4">Weight Over Time</h2>
+            <div id="weight-chart" phx-hook="ProgressChart" data-chart={@chart_data}>
+              <canvas></canvas>
+            </div>
+          </div>
+        <% end %>
+
+        <%!-- History Table --%>
+        <div class="bg-white rounded-2xl shadow-lg p-6">
+          <h2 class="text-lg font-semibold mb-4">History</h2>
+          <%= if @metrics == [] do %>
+            <p class="text-gray-500">No entries yet.</p>
+          <% else %>
+            <div class="overflow-x-auto">
+              <table class="table table-zebra w-full">
+                <thead>
+                  <tr>
+                    <th>Date</th>
+                    <th>Weight</th>
+                    <th>Body Fat</th>
+                    <th>Chest</th>
+                    <th>Waist</th>
+                    <th>Hips</th>
+                    <th>Bicep</th>
+                    <th>Thigh</th>
+                    <th>Notes</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <%= for metric <- @metrics do %>
+                    <tr>
+                      <td>{metric.date}</td>
+                      <td>{format_decimal(metric.weight_kg)}</td>
+                      <td>{format_decimal(metric.body_fat_pct)}</td>
+                      <td>{format_decimal(metric.chest_cm)}</td>
+                      <td>{format_decimal(metric.waist_cm)}</td>
+                      <td>{format_decimal(metric.hips_cm)}</td>
+                      <td>{format_decimal(metric.bicep_cm)}</td>
+                      <td>{format_decimal(metric.thigh_cm)}</td>
+                      <td class="max-w-[200px] truncate">{metric.notes || "—"}</td>
+                    </tr>
+                  <% end %>
+                </tbody>
+              </table>
+            </div>
+          <% end %>
+        </div>
+      </div>
+    </div>
+    """
+  end
+end

--- a/lib/gym_studio_web/live/trainer/client_progress_live.ex
+++ b/lib/gym_studio_web/live/trainer/client_progress_live.ex
@@ -1,0 +1,138 @@
+defmodule GymStudioWeb.Trainer.ClientProgressLive do
+  @moduledoc """
+  Trainer view of a client's exercise progress — read-only.
+  Shows exercise history cards with PR badges and category filter.
+  Reuses logic from `GymStudio.Progress`.
+  """
+  use GymStudioWeb, :live_view
+
+  alias GymStudio.{Accounts, Progress, Scheduling}
+
+  @impl true
+  def mount(%{"client_id" => client_id}, _session, socket) do
+    trainer = socket.assigns.current_scope.user
+
+    if Scheduling.trainer_has_client?(trainer.id, client_id) do
+      client = Accounts.get_user!(client_id)
+      categories = Progress.list_categories()
+      exercises = Progress.list_client_exercises(client_id)
+
+      socket =
+        socket
+        |> assign(page_title: "#{client.name || "Client"}'s Progress")
+        |> assign(client: client)
+        |> assign(exercises: exercises)
+        |> assign(categories: categories)
+        |> assign(selected_category: nil)
+
+      {:ok, socket}
+    else
+      socket =
+        socket
+        |> put_flash(:error, "Not authorized to view this client's progress.")
+        |> redirect(to: ~p"/trainer/clients")
+
+      {:ok, socket}
+    end
+  end
+
+  @impl true
+  def handle_event("filter_category", %{"category" => category}, socket) do
+    client_id = socket.assigns.client.id
+    category = if category == "", do: nil, else: category
+
+    exercises =
+      if category do
+        Progress.list_client_exercises(client_id, category: category)
+      else
+        Progress.list_client_exercises(client_id)
+      end
+
+    {:noreply, assign(socket, exercises: exercises, selected_category: category)}
+  end
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <div class="min-h-screen bg-gray-100 py-8">
+      <div class="container mx-auto px-4">
+        <div class="mb-6">
+          <.link navigate={~p"/trainer/clients"} class="btn btn-ghost btn-sm mb-2">
+            ← Back to My Clients
+          </.link>
+          <h1 class="text-2xl md:text-3xl font-bold text-gray-800">
+            {@client.name || "Client"}'s Progress
+          </h1>
+          <p class="text-gray-600 mt-1">Exercise history and personal records</p>
+          <div class="mt-2 flex gap-2">
+            <.link
+              navigate={~p"/trainer/clients/#{@client.id}/progress/metrics"}
+              class="btn btn-primary btn-sm"
+            >
+              📏 Body Metrics
+            </.link>
+            <.link
+              navigate={~p"/trainer/clients/#{@client.id}/progress/goals"}
+              class="btn btn-primary btn-sm"
+            >
+              🎯 Goals
+            </.link>
+          </div>
+        </div>
+
+        <%!-- Category Filter --%>
+        <div class="mb-6">
+          <form phx-change="filter_category">
+            <select name="category" class="select select-bordered w-full max-w-xs">
+              <option value="">All Categories</option>
+              <%= for cat <- @categories do %>
+                <option value={cat} selected={@selected_category == cat}>
+                  {String.capitalize(cat)}
+                </option>
+              <% end %>
+            </select>
+          </form>
+        </div>
+
+        <%!-- Exercise Cards --%>
+        <%= if @exercises == [] do %>
+          <div class="bg-white rounded-2xl shadow-lg p-8 text-center">
+            <p class="text-gray-500 text-lg">No exercises logged yet.</p>
+          </div>
+        <% else %>
+          <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+            <%= for exercise <- @exercises do %>
+              <div class="bg-white rounded-2xl shadow-lg p-5">
+                <div class="flex items-start justify-between mb-3">
+                  <div>
+                    <h3 class="font-semibold text-gray-800">{exercise.exercise_name}</h3>
+                    <span class="text-xs text-gray-500 bg-gray-100 rounded-full px-2 py-1">
+                      {String.capitalize(exercise.category)}
+                    </span>
+                  </div>
+                  <%= if exercise.has_pr do %>
+                    <span class="text-2xl" title="Personal Record">🏆</span>
+                  <% end %>
+                </div>
+
+                <div class="space-y-1 text-sm text-gray-600">
+                  <%= if exercise.latest_weight_kg do %>
+                    <p>Weight: <span class="font-medium">{exercise.latest_weight_kg} kg</span></p>
+                  <% end %>
+                  <%= if exercise.latest_sets do %>
+                    <p>Sets: <span class="font-medium">{exercise.latest_sets}</span></p>
+                  <% end %>
+                  <%= if exercise.latest_reps do %>
+                    <p>Reps: <span class="font-medium">{exercise.latest_reps}</span></p>
+                  <% end %>
+                  <p class="text-gray-400">{exercise.total_sessions} session(s) logged</p>
+                </div>
+              </div>
+            <% end %>
+          </div>
+        <% end %>
+      </div>
+    </div>
+    """
+  end
+end

--- a/lib/gym_studio_web/live/trainer/dashboard_live.ex
+++ b/lib/gym_studio_web/live/trainer/dashboard_live.ex
@@ -189,6 +189,12 @@ defmodule GymStudioWeb.Trainer.DashboardLive do
           </div>
         </div>
 
+        <div class="flex gap-3 mb-8">
+          <.link navigate={~p"/trainer/clients"} class="btn btn-primary btn-sm">
+            👥 My Clients
+          </.link>
+        </div>
+
         <div class="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-8">
           <!-- Today's Sessions -->
           <div class="card bg-base-100 shadow-xl">

--- a/lib/gym_studio_web/router.ex
+++ b/lib/gym_studio_web/router.ex
@@ -62,6 +62,10 @@ defmodule GymStudioWeb.Router do
       live "/exercises", ExercisesLive, :index
       live "/sessions/:id/log", SessionLogLive, :index
       live "/sessions/:id/exercises", SessionLogLive, :index
+      live "/clients", ClientListLive, :index
+      live "/clients/:client_id/progress", ClientProgressLive, :index
+      live "/clients/:client_id/progress/metrics", ClientMetricsLive, :index
+      live "/clients/:client_id/progress/goals", ClientGoalsLive, :index
     end
   end
 

--- a/test/gym_studio/scheduling_trainer_clients_test.exs
+++ b/test/gym_studio/scheduling_trainer_clients_test.exs
@@ -1,0 +1,99 @@
+defmodule GymStudio.Scheduling.TrainerClientsTest do
+  use GymStudio.DataCase
+
+  import GymStudio.AccountsFixtures
+  import GymStudio.SchedulingFixtures
+
+  alias GymStudio.Scheduling
+
+  setup do
+    trainer_user = user_fixture(%{role: :trainer, name: "Coach Dan"})
+    trainer = trainer_fixture(%{user_id: trainer_user.id})
+    admin = user_fixture(%{role: :admin})
+
+    trainer =
+      trainer
+      |> GymStudio.Accounts.Trainer.approval_changeset(admin)
+      |> GymStudio.Repo.update!()
+
+    %{trainer_user: trainer_user, trainer: trainer, admin: admin}
+  end
+
+  describe "list_trainer_clients/2" do
+    test "returns empty list when no sessions", %{trainer_user: trainer_user} do
+      assert Scheduling.list_trainer_clients(trainer_user.id) == []
+    end
+
+    test "returns unique clients with stats", %{trainer_user: trainer_user} do
+      client = user_fixture(%{role: :client, name: "Alice"})
+      _c = client_fixture(%{user_id: client.id})
+
+      _s1 =
+        training_session_fixture(%{
+          client_id: client.id,
+          trainer_id: trainer_user.id,
+          status: "confirmed"
+        })
+
+      _s2 =
+        training_session_fixture(%{
+          client_id: client.id,
+          trainer_id: trainer_user.id,
+          status: "completed",
+          scheduled_at: DateTime.utc_now() |> DateTime.add(-1, :day) |> DateTime.truncate(:second)
+        })
+
+      [result] = Scheduling.list_trainer_clients(trainer_user.id)
+      assert result.name == "Alice"
+      assert result.total_sessions == 2
+    end
+
+    test "search filters by name", %{trainer_user: trainer_user} do
+      alice = user_fixture(%{role: :client, name: "Alice"})
+      _ac = client_fixture(%{user_id: alice.id})
+      bob = user_fixture(%{role: :client, name: "Bob"})
+      _bc = client_fixture(%{user_id: bob.id})
+
+      _s1 =
+        training_session_fixture(%{
+          client_id: alice.id,
+          trainer_id: trainer_user.id,
+          status: "confirmed"
+        })
+
+      _s2 =
+        training_session_fixture(%{
+          client_id: bob.id,
+          trainer_id: trainer_user.id,
+          status: "confirmed"
+        })
+
+      results = Scheduling.list_trainer_clients(trainer_user.id, search: "Alice")
+      assert length(results) == 1
+      assert hd(results).name == "Alice"
+    end
+  end
+
+  describe "trainer_has_client?/2" do
+    test "returns true when trainer has session with client", %{trainer_user: trainer_user} do
+      client = user_fixture(%{role: :client})
+      _c = client_fixture(%{user_id: client.id})
+
+      _s =
+        training_session_fixture(%{
+          client_id: client.id,
+          trainer_id: trainer_user.id,
+          status: "confirmed"
+        })
+
+      assert Scheduling.trainer_has_client?(trainer_user.id, client.id)
+    end
+
+    test "returns false when no sessions", %{trainer_user: trainer_user} do
+      client = user_fixture(%{role: :client})
+      _c = client_fixture(%{user_id: client.id})
+
+      refute Scheduling.trainer_has_client?(trainer_user.id, client.id)
+    end
+  end
+end

--- a/test/gym_studio_web/live/trainer/client_list_live_test.exs
+++ b/test/gym_studio_web/live/trainer/client_list_live_test.exs
@@ -1,0 +1,90 @@
+defmodule GymStudioWeb.Trainer.ClientListLiveTest do
+  use GymStudioWeb.ConnCase
+
+  import Phoenix.LiveViewTest
+  import GymStudio.AccountsFixtures
+  import GymStudio.SchedulingFixtures
+
+  setup do
+    trainer_user = user_fixture(%{role: :trainer, name: "Coach Dan"})
+    trainer = trainer_fixture(%{user_id: trainer_user.id})
+    admin = user_fixture(%{role: :admin})
+
+    trainer =
+      trainer
+      |> GymStudio.Accounts.Trainer.approval_changeset(admin)
+      |> GymStudio.Repo.update!()
+
+    %{trainer_user: trainer_user, trainer: trainer, admin: admin}
+  end
+
+  describe "Client List" do
+    test "renders empty state when no clients", %{conn: conn, trainer_user: trainer_user} do
+      conn = log_in_user(conn, trainer_user)
+      {:ok, _view, html} = live(conn, ~p"/trainer/clients")
+
+      assert html =~ "My Clients"
+      assert html =~ "No clients found"
+    end
+
+    test "renders client cards with session stats", %{
+      conn: conn,
+      trainer_user: trainer_user
+    } do
+      client_user = user_fixture(%{role: :client, name: "Alice Cooper"})
+      _client = client_fixture(%{user_id: client_user.id})
+
+      _session =
+        training_session_fixture(%{
+          client_id: client_user.id,
+          trainer_id: trainer_user.id,
+          status: "confirmed"
+        })
+
+      _session2 =
+        training_session_fixture(%{
+          client_id: client_user.id,
+          trainer_id: trainer_user.id,
+          status: "completed",
+          scheduled_at: DateTime.utc_now() |> DateTime.add(-1, :day) |> DateTime.truncate(:second)
+        })
+
+      conn = log_in_user(conn, trainer_user)
+      {:ok, _view, html} = live(conn, ~p"/trainer/clients")
+
+      assert html =~ "Alice Cooper"
+      assert html =~ "Total sessions"
+      assert html =~ "2"
+      assert html =~ "View Progress"
+    end
+
+    test "search filters clients by name", %{conn: conn, trainer_user: trainer_user} do
+      alice = user_fixture(%{role: :client, name: "Alice Cooper"})
+      _alice_client = client_fixture(%{user_id: alice.id})
+
+      bob = user_fixture(%{role: :client, name: "Bob Marley"})
+      _bob_client = client_fixture(%{user_id: bob.id})
+
+      _s1 =
+        training_session_fixture(%{
+          client_id: alice.id,
+          trainer_id: trainer_user.id,
+          status: "confirmed"
+        })
+
+      _s2 =
+        training_session_fixture(%{
+          client_id: bob.id,
+          trainer_id: trainer_user.id,
+          status: "confirmed"
+        })
+
+      conn = log_in_user(conn, trainer_user)
+      {:ok, view, _html} = live(conn, ~p"/trainer/clients")
+
+      html = render_change(view, "search", %{"search" => "Alice"})
+      assert html =~ "Alice Cooper"
+      refute html =~ "Bob Marley"
+    end
+  end
+end

--- a/test/gym_studio_web/live/trainer/client_progress_live_test.exs
+++ b/test/gym_studio_web/live/trainer/client_progress_live_test.exs
@@ -1,0 +1,124 @@
+defmodule GymStudioWeb.Trainer.ClientProgressLiveTest do
+  use GymStudioWeb.ConnCase
+
+  import Phoenix.LiveViewTest
+  import GymStudio.AccountsFixtures
+  import GymStudio.SchedulingFixtures
+
+  setup do
+    trainer_user = user_fixture(%{role: :trainer, name: "Coach Dan"})
+    trainer = trainer_fixture(%{user_id: trainer_user.id})
+    admin = user_fixture(%{role: :admin})
+
+    trainer =
+      trainer
+      |> GymStudio.Accounts.Trainer.approval_changeset(admin)
+      |> GymStudio.Repo.update!()
+
+    client_user = user_fixture(%{role: :client, name: "Alice Cooper"})
+    _client = client_fixture(%{user_id: client_user.id})
+
+    %{
+      trainer_user: trainer_user,
+      trainer: trainer,
+      admin: admin,
+      client_user: client_user
+    }
+  end
+
+  describe "authorized trainer" do
+    setup %{trainer_user: trainer_user, client_user: client_user} do
+      _session =
+        training_session_fixture(%{
+          client_id: client_user.id,
+          trainer_id: trainer_user.id,
+          status: "confirmed"
+        })
+
+      :ok
+    end
+
+    test "renders client progress page", %{
+      conn: conn,
+      trainer_user: trainer_user,
+      client_user: client_user
+    } do
+      conn = log_in_user(conn, trainer_user)
+      {:ok, _view, html} = live(conn, ~p"/trainer/clients/#{client_user.id}/progress")
+
+      assert html =~ "Alice Cooper&#39;s Progress"
+      assert html =~ "Back to My Clients"
+      assert html =~ "Body Metrics"
+      assert html =~ "Goals"
+    end
+
+    test "renders client metrics page", %{
+      conn: conn,
+      trainer_user: trainer_user,
+      client_user: client_user
+    } do
+      conn = log_in_user(conn, trainer_user)
+      {:ok, _view, html} = live(conn, ~p"/trainer/clients/#{client_user.id}/progress/metrics")
+
+      assert html =~ "Alice Cooper&#39;s Body Metrics"
+      assert html =~ "Back to Progress"
+      # No form for creating/editing (read-only)
+      refute html =~ "Log New Entry"
+    end
+
+    test "renders client goals page", %{
+      conn: conn,
+      trainer_user: trainer_user,
+      client_user: client_user
+    } do
+      conn = log_in_user(conn, trainer_user)
+      {:ok, _view, html} = live(conn, ~p"/trainer/clients/#{client_user.id}/progress/goals")
+
+      assert html =~ "Alice Cooper&#39;s Goals"
+      assert html =~ "Back to Progress"
+      # No form for creating goals (read-only)
+      refute html =~ "New Goal"
+    end
+  end
+
+  describe "unauthorized trainer" do
+    test "redirects when trainer has no sessions with client", %{
+      conn: conn,
+      trainer_user: trainer_user,
+      client_user: client_user
+    } do
+      conn = log_in_user(conn, trainer_user)
+
+      assert {:error, {:redirect, %{to: "/trainer/clients", flash: %{"error" => msg}}}} =
+               live(conn, ~p"/trainer/clients/#{client_user.id}/progress")
+
+      assert msg =~ "Not authorized"
+    end
+
+    test "redirects from metrics when unauthorized", %{
+      conn: conn,
+      trainer_user: trainer_user,
+      client_user: client_user
+    } do
+      conn = log_in_user(conn, trainer_user)
+
+      assert {:error, {:redirect, %{to: "/trainer/clients", flash: %{"error" => msg}}}} =
+               live(conn, ~p"/trainer/clients/#{client_user.id}/progress/metrics")
+
+      assert msg =~ "Not authorized"
+    end
+
+    test "redirects from goals when unauthorized", %{
+      conn: conn,
+      trainer_user: trainer_user,
+      client_user: client_user
+    } do
+      conn = log_in_user(conn, trainer_user)
+
+      assert {:error, {:redirect, %{to: "/trainer/clients", flash: %{"error" => msg}}}} =
+               live(conn, ~p"/trainer/clients/#{client_user.id}/progress/goals")
+
+      assert msg =~ "Not authorized"
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Implements **#49** (Trainer Client List) and **#47** (Trainer View Client Progress) together.

### New Routes
- `/trainer/clients` — Searchable list of all clients the trainer has sessions with
- `/trainer/clients/:id/progress` — Exercise history with PR badges and category filter
- `/trainer/clients/:id/progress/metrics` — Body metrics and weight chart (read-only)
- `/trainer/clients/:id/progress/goals` — Fitness goals with progress bars (read-only)

### Key Details
- **Authorization**: Trainer must have at least one training_session with the client
- **Read-only**: No create/edit/delete forms (that's #48)
- **Reuse**: Existing context functions from Progress, Metrics, Goals
- **14 new tests**, all 436 pass with 0 warnings

Closes #47, closes #49