### PR TITLE
feat: trainer creates goals and logs metrics for clients (#48)

### DIFF
--- a/docs/progress-tracking.md
+++ b/docs/progress-tracking.md
@@ -114,9 +114,26 @@ Trainers can view their clients' progress in read-only mode.
 - `list_trainer_clients(trainer_id, opts)` — Distinct clients with total sessions and last session date; supports `:search` option
 - `trainer_has_client?(trainer_id, client_id)` — Boolean check for authorization
 
+### Trainer Write Capabilities
+Trainers can create, edit, and delete metrics and goals for their clients:
+
+#### Metrics
+- **Log New Entry**: Same form as client — trainer fills in date, weight, body fat, measurements, notes
+- `logged_by_id` = trainer's user ID (tracks who logged the entry)
+- Trainer can **edit/delete** entries they logged, but NOT entries the client logged
+- UI shows "Client entry" label for client-logged metrics (no edit/delete buttons)
+
+#### Goals
+- **New Goal**: Same form as client — trainer creates goals for the client
+- `created_by_id` = trainer's user ID, `client_id` = client's user ID
+- Trainer can **update progress** on any of the client's goals
+- Trainer can **achieve/abandon** any of the client's goals
+- Trainer can **delete** goals they created, but NOT goals the client created
+- Client-created goals show no delete button for the trainer
+
 ### Key Design Decisions
-- **Read-only**: Trainer views have no create/edit/delete forms (that's issue #48)
-- **Reuse**: All data fetching reuses existing context functions from `Progress`, `Metrics`, and `Goals`
+- **Reuse**: All data fetching and mutations reuse existing context functions from `Progress`, `Metrics`, and `Goals`
+- **Ownership tracking**: `logged_by_id` (metrics) and `created_by_id` (goals) enforce edit/delete permissions
 - **Search**: ILIKE with sanitized wildcards (`%`, `_`, `\` escaped)
 
 ## Authorization

--- a/lib/gym_studio_web/live/trainer/client_goals_live.ex
+++ b/lib/gym_studio_web/live/trainer/client_goals_live.ex
@@ -1,11 +1,13 @@
 defmodule GymStudioWeb.Trainer.ClientGoalsLive do
   @moduledoc """
-  Trainer read-only view of a client's fitness goals and progress bars.
-  Reuses logic from `GymStudio.Goals`.
+  Trainer view of a client's fitness goals with write capabilities.
+  Trainers can create goals, update progress, achieve/abandon goals,
+  and delete goals they created. Client-created goals are read-only.
   """
   use GymStudioWeb, :live_view
 
   alias GymStudio.{Accounts, Goals, Scheduling}
+  alias GymStudio.Goals.FitnessGoal
 
   @impl true
   def mount(%{"client_id" => client_id}, _session, socket) do
@@ -13,14 +15,14 @@ defmodule GymStudioWeb.Trainer.ClientGoalsLive do
 
     if Scheduling.trainer_has_client?(trainer.id, client_id) do
       client = Accounts.get_user!(client_id)
-      goals = Goals.list_goals(client_id)
 
       socket =
         socket
         |> assign(page_title: "#{client.name || "Client"}'s Goals")
-        |> assign(client: client)
-        |> assign(goals: goals)
-        |> assign(status_filter: "all")
+        |> assign(client: client, trainer: trainer)
+        |> assign(status_filter: "all", editing_progress: nil)
+        |> assign_goals()
+        |> assign_new_form()
 
       {:ok, socket}
     else
@@ -34,11 +36,133 @@ defmodule GymStudioWeb.Trainer.ClientGoalsLive do
   end
 
   @impl true
+  def handle_event("save_goal", %{"fitness_goal" => params}, socket) do
+    trainer = socket.assigns.trainer
+    client = socket.assigns.client
+
+    attrs =
+      params
+      |> Map.put("client_id", client.id)
+      |> Map.put("created_by_id", trainer.id)
+
+    case Goals.create_goal(attrs) do
+      {:ok, _goal} ->
+        {:noreply,
+         socket
+         |> assign_goals()
+         |> assign_new_form()
+         |> put_flash(:info, "Goal created successfully.")}
+
+      {:error, %Ecto.Changeset{} = changeset} ->
+        {:noreply, assign(socket, form: to_form(changeset))}
+    end
+  end
+
   def handle_event("filter_status", %{"status" => status}, socket) do
+    {:noreply,
+     socket
+     |> assign(status_filter: status)
+     |> assign_goals(status)}
+  end
+
+  def handle_event("achieve", %{"id" => id}, socket) do
+    client = socket.assigns.client
+    goal = Goals.get_goal!(id)
+
+    if goal.client_id != client.id do
+      {:noreply, put_flash(socket, :error, "Unauthorized")}
+    else
+      {:ok, _} = Goals.achieve_goal(goal)
+
+      {:noreply,
+       socket
+       |> assign_goals()
+       |> put_flash(:info, "Goal achieved! 🏆")}
+    end
+  end
+
+  def handle_event("abandon", %{"id" => id}, socket) do
+    client = socket.assigns.client
+    goal = Goals.get_goal!(id)
+
+    if goal.client_id != client.id do
+      {:noreply, put_flash(socket, :error, "Unauthorized")}
+    else
+      {:ok, _} = Goals.abandon_goal(goal)
+
+      {:noreply,
+       socket
+       |> assign_goals()
+       |> put_flash(:info, "Goal abandoned.")}
+    end
+  end
+
+  def handle_event("delete", %{"id" => id}, socket) do
+    trainer = socket.assigns.trainer
+    goal = Goals.get_goal!(id)
+
+    if goal.created_by_id != trainer.id do
+      {:noreply, put_flash(socket, :error, "You can only delete goals you created.")}
+    else
+      case Goals.delete_goal(goal) do
+        {:ok, _} ->
+          {:noreply,
+           socket
+           |> assign_goals()
+           |> put_flash(:info, "Goal deleted.")}
+
+        {:error, :not_active} ->
+          {:noreply, put_flash(socket, :error, "Only active goals can be deleted.")}
+      end
+    end
+  end
+
+  def handle_event("edit_progress", %{"id" => id}, socket) do
+    {:noreply, assign(socket, editing_progress: id)}
+  end
+
+  def handle_event("cancel_progress", _params, socket) do
+    {:noreply, assign(socket, editing_progress: nil)}
+  end
+
+  def handle_event("save_progress", %{"goal_id" => id, "current_value" => value}, socket) do
+    client = socket.assigns.client
+    goal = Goals.get_goal!(id)
+
+    if goal.client_id != client.id do
+      {:noreply, put_flash(socket, :error, "Unauthorized")}
+    else
+      case Goals.update_progress(goal, value) do
+        {:ok, updated} ->
+          msg =
+            if updated.status == "achieved",
+              do: "Progress updated — goal achieved! 🏆",
+              else: "Progress updated."
+
+          {:noreply,
+           socket
+           |> assign(editing_progress: nil)
+           |> assign_goals()
+           |> put_flash(:info, msg)}
+
+        {:error, _} ->
+          {:noreply, put_flash(socket, :error, "Invalid value.")}
+      end
+    end
+  end
+
+  # ── Private ──────────────────────────────────────────────────────
+
+  defp assign_goals(socket, status_filter \\ nil) do
     client_id = socket.assigns.client.id
-    opts = if status in [nil, "", "all"], do: [], else: [status: status]
-    goals = Goals.list_goals(client_id, opts)
-    {:noreply, assign(socket, goals: goals, status_filter: status)}
+    filter = status_filter || socket.assigns.status_filter
+    opts = if filter in [nil, "", "all"], do: [], else: [status: filter]
+    assign(socket, goals: Goals.list_goals(client_id, opts))
+  end
+
+  defp assign_new_form(socket) do
+    changeset = Goals.change_goal(%FitnessGoal{})
+    assign(socket, form: to_form(changeset))
   end
 
   defp progress_percent(current, target) do
@@ -64,6 +188,10 @@ defmodule GymStudioWeb.Trainer.ClientGoalsLive do
   defp status_label("abandoned"), do: "Abandoned"
   defp status_label(s), do: s
 
+  defp trainer_created?(goal, trainer) do
+    goal.created_by_id == trainer.id
+  end
+
   @impl true
   def render(assigns) do
     ~H"""
@@ -80,6 +208,85 @@ defmodule GymStudioWeb.Trainer.ClientGoalsLive do
             {@client.name || "Client"}'s Goals
           </h1>
           <p class="text-gray-600 mt-1">Fitness goals and progress</p>
+        </div>
+
+        <%!-- Create Goal Form --%>
+        <div class="bg-white rounded-2xl shadow-lg p-6 mb-6">
+          <h2 class="text-lg font-semibold mb-4">New Goal</h2>
+          <.form for={@form} phx-submit="save_goal" class="space-y-4">
+            <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+              <div>
+                <label class="label"><span class="label-text">Title</span></label>
+                <input
+                  type="text"
+                  name="fitness_goal[title]"
+                  value={@form[:title].value}
+                  class="input input-bordered w-full"
+                  required
+                  placeholder="e.g. Bench Press 100kg"
+                />
+                <%= for {msg, _} <- @form[:title].errors do %>
+                  <p class="mt-1 text-sm text-error">Title: {msg}</p>
+                <% end %>
+              </div>
+              <div>
+                <label class="label"><span class="label-text">Target Value</span></label>
+                <input
+                  type="number"
+                  name="fitness_goal[target_value]"
+                  value={@form[:target_value].value}
+                  class="input input-bordered w-full"
+                  required
+                  step="any"
+                  min="0.01"
+                  placeholder="e.g. 100"
+                />
+                <%= for {msg, _} <- @form[:target_value].errors do %>
+                  <p class="mt-1 text-sm text-error">Target value: {msg}</p>
+                <% end %>
+              </div>
+              <div>
+                <label class="label"><span class="label-text">Unit</span></label>
+                <select
+                  name="fitness_goal[target_unit]"
+                  class="select select-bordered w-full"
+                  required
+                >
+                  <option value="">Select unit</option>
+                  <option value="kg" selected={@form[:target_unit].value == "kg"}>kg</option>
+                  <option value="kg_loss" selected={@form[:target_unit].value == "kg_loss"}>
+                    kg (loss)
+                  </option>
+                  <option value="minutes" selected={@form[:target_unit].value == "minutes"}>
+                    minutes
+                  </option>
+                  <option value="reps" selected={@form[:target_unit].value == "reps"}>reps</option>
+                  <option value="sessions" selected={@form[:target_unit].value == "sessions"}>
+                    sessions
+                  </option>
+                </select>
+              </div>
+              <div>
+                <label class="label"><span class="label-text">Target Date (optional)</span></label>
+                <input
+                  type="date"
+                  name="fitness_goal[target_date]"
+                  value={@form[:target_date].value}
+                  class="input input-bordered w-full"
+                />
+              </div>
+            </div>
+            <div>
+              <label class="label"><span class="label-text">Description (optional)</span></label>
+              <textarea
+                name="fitness_goal[description]"
+                class="textarea textarea-bordered w-full"
+                rows="2"
+                placeholder="Any notes about this goal..."
+              >{@form[:description].value}</textarea>
+            </div>
+            <button type="submit" class="btn btn-primary">Create Goal</button>
+          </.form>
         </div>
 
         <%!-- Status Filter --%>
@@ -112,6 +319,7 @@ defmodule GymStudioWeb.Trainer.ClientGoalsLive do
                   <p class="text-gray-500 text-sm mb-3">{goal.description}</p>
                 <% end %>
 
+                <%!-- Progress Bar --%>
                 <div class="mb-3">
                   <div class="flex justify-between text-sm text-gray-600 mb-1">
                     <span>{goal.current_value} / {goal.target_value} {goal.target_unit}</span>
@@ -126,7 +334,70 @@ defmodule GymStudioWeb.Trainer.ClientGoalsLive do
                 </div>
 
                 <%= if goal.target_date do %>
-                  <p class="text-xs text-gray-400">Target: {goal.target_date}</p>
+                  <p class="text-xs text-gray-400 mb-3">Target: {goal.target_date}</p>
+                <% end %>
+
+                <%!-- Update Progress (trainer can update any active goal) --%>
+                <%= if goal.status == "active" do %>
+                  <%= if @editing_progress == goal.id do %>
+                    <form phx-submit="save_progress" class="flex gap-2 mb-3">
+                      <input type="hidden" name="goal_id" value={goal.id} />
+                      <input
+                        type="number"
+                        name="current_value"
+                        value={goal.current_value}
+                        class="input input-bordered input-sm flex-1"
+                        step="any"
+                        min="0"
+                      />
+                      <button type="submit" class="btn btn-primary btn-sm">Save</button>
+                      <button
+                        type="button"
+                        class="btn btn-ghost btn-sm"
+                        phx-click="cancel_progress"
+                      >
+                        Cancel
+                      </button>
+                    </form>
+                  <% else %>
+                    <button
+                      class="btn btn-outline btn-sm mb-3"
+                      phx-click="edit_progress"
+                      phx-value-id={goal.id}
+                    >
+                      Update Progress
+                    </button>
+                  <% end %>
+                <% end %>
+
+                <%!-- Actions --%>
+                <%= if goal.status == "active" do %>
+                  <div class="flex gap-2 flex-wrap">
+                    <button
+                      class="btn btn-success btn-xs"
+                      phx-click="achieve"
+                      phx-value-id={goal.id}
+                    >
+                      ✓ Achieve
+                    </button>
+                    <button
+                      class="btn btn-warning btn-xs"
+                      phx-click="abandon"
+                      phx-value-id={goal.id}
+                    >
+                      Abandon
+                    </button>
+                    <%= if trainer_created?(goal, @trainer) do %>
+                      <button
+                        class="btn btn-error btn-xs"
+                        phx-click="delete"
+                        phx-value-id={goal.id}
+                        data-confirm="Are you sure you want to delete this goal?"
+                      >
+                        Delete
+                      </button>
+                    <% end %>
+                  </div>
                 <% end %>
               </div>
             <% end %>

--- a/lib/gym_studio_web/live/trainer/client_metrics_live.ex
+++ b/lib/gym_studio_web/live/trainer/client_metrics_live.ex
@@ -1,11 +1,13 @@
 defmodule GymStudioWeb.Trainer.ClientMetricsLive do
   @moduledoc """
-  Trainer read-only view of a client's body metrics and weight chart.
-  Reuses logic from `GymStudio.Metrics`.
+  Trainer view of a client's body metrics with write capabilities.
+  Trainers can log new entries, edit/delete entries they logged,
+  and view the client's full metrics history and weight chart.
   """
   use GymStudioWeb, :live_view
 
   alias GymStudio.{Accounts, Metrics, Scheduling}
+  alias GymStudio.Metrics.BodyMetric
 
   @impl true
   def mount(%{"client_id" => client_id}, _session, socket) do
@@ -13,15 +15,13 @@ defmodule GymStudioWeb.Trainer.ClientMetricsLive do
 
     if Scheduling.trainer_has_client?(trainer.id, client_id) do
       client = Accounts.get_user!(client_id)
-      metrics = Metrics.list_metrics(client_id)
-      chart_data = build_weight_chart_data(client_id)
 
       socket =
         socket
         |> assign(page_title: "#{client.name || "Client"}'s Body Metrics")
-        |> assign(client: client)
-        |> assign(metrics: metrics)
-        |> assign(chart_data: chart_data)
+        |> assign(client: client, trainer: trainer, editing: nil)
+        |> reload_metrics()
+        |> assign_new_form()
 
       {:ok, socket}
     else
@@ -34,18 +34,104 @@ defmodule GymStudioWeb.Trainer.ClientMetricsLive do
     end
   end
 
+  @impl true
+  def handle_event("save", %{"body_metric" => params}, socket) do
+    trainer = socket.assigns.trainer
+    client = socket.assigns.client
+
+    attrs =
+      params
+      |> Map.put("user_id", client.id)
+      |> Map.put("logged_by_id", trainer.id)
+
+    result =
+      case socket.assigns.editing do
+        nil -> Metrics.create_metric(attrs)
+        metric -> Metrics.update_metric(metric, attrs)
+      end
+
+    case result do
+      {:ok, _metric} ->
+        {:noreply,
+         socket
+         |> assign(editing: nil)
+         |> reload_metrics()
+         |> assign_new_form()
+         |> put_flash(:info, "Body metric saved successfully.")}
+
+      {:error, %Ecto.Changeset{} = changeset} ->
+        {:noreply, assign(socket, form: to_form(changeset))}
+    end
+  end
+
+  def handle_event("edit", %{"id" => id}, socket) do
+    trainer = socket.assigns.trainer
+    metric = Metrics.get_metric!(id)
+
+    if metric.logged_by_id != trainer.id do
+      {:noreply, put_flash(socket, :error, "You can only edit entries you logged.")}
+    else
+      changeset = Metrics.change_metric(metric)
+
+      {:noreply,
+       socket
+       |> assign(editing: metric)
+       |> assign(form: to_form(changeset))}
+    end
+  end
+
+  def handle_event("cancel_edit", _params, socket) do
+    {:noreply,
+     socket
+     |> assign(editing: nil)
+     |> assign_new_form()}
+  end
+
+  def handle_event("delete", %{"id" => id}, socket) do
+    trainer = socket.assigns.trainer
+    metric = Metrics.get_metric!(id)
+
+    if metric.logged_by_id != trainer.id do
+      {:noreply, put_flash(socket, :error, "You can only delete entries you logged.")}
+    else
+      {:ok, _} = Metrics.delete_metric(metric)
+
+      {:noreply,
+       socket
+       |> assign(editing: nil)
+       |> reload_metrics()
+       |> assign_new_form()
+       |> put_flash(:info, "Body metric deleted.")}
+    end
+  end
+
+  # ── Private ──────────────────────────────────────────────────────
+
+  defp reload_metrics(socket) do
+    client_id = socket.assigns.client.id
+    metrics = Metrics.list_metrics(client_id)
+    chart_data = build_weight_chart_data(client_id)
+    assign(socket, metrics: metrics, chart_data: chart_data)
+  end
+
+  defp assign_new_form(socket) do
+    changeset = Metrics.change_metric(%BodyMetric{date: Date.utc_today()})
+    assign(socket, form: to_form(changeset))
+  end
+
   defp build_weight_chart_data(user_id) do
     history = Metrics.get_metric_history(user_id, :weight_kg)
     labels = Enum.map(history, fn {date, _} -> Date.to_string(date) end)
-
-    values =
-      Enum.map(history, fn {_, value} -> Decimal.to_float(value) end)
-
+    values = Enum.map(history, fn {_, value} -> Decimal.to_float(value) end)
     Jason.encode!(%{labels: labels, values: values, y_label: "Weight (kg)"})
   end
 
   defp format_decimal(nil), do: "—"
   defp format_decimal(val), do: Decimal.to_string(val)
+
+  defp trainer_logged?(metric, trainer) do
+    metric.logged_by_id == trainer.id
+  end
 
   @impl true
   def render(assigns) do
@@ -62,6 +148,126 @@ defmodule GymStudioWeb.Trainer.ClientMetricsLive do
             </h1>
             <p class="text-gray-600 mt-1">Weight, body fat, and measurements</p>
           </div>
+        </div>
+
+        <%!-- Log / Edit Form --%>
+        <div class="bg-white rounded-2xl shadow-lg p-6 mb-6">
+          <h2 class="text-lg font-semibold mb-4">
+            {if @editing, do: "Edit Entry", else: "Log New Entry"}
+          </h2>
+          <form phx-submit="save" class="space-y-4">
+            <div class="grid grid-cols-2 md:grid-cols-4 gap-4">
+              <div class="form-control">
+                <label class="label"><span class="label-text">Date</span></label>
+                <input
+                  type="date"
+                  name="body_metric[date]"
+                  value={Phoenix.HTML.Form.input_value(@form, :date)}
+                  class="input input-bordered w-full"
+                  required
+                />
+              </div>
+              <div class="form-control">
+                <label class="label"><span class="label-text">Weight (kg)</span></label>
+                <input
+                  type="number"
+                  step="0.1"
+                  name="body_metric[weight_kg]"
+                  value={Phoenix.HTML.Form.input_value(@form, :weight_kg)}
+                  class="input input-bordered w-full"
+                  placeholder="e.g. 75.5"
+                />
+              </div>
+              <div class="form-control">
+                <label class="label"><span class="label-text">Body Fat %</span></label>
+                <input
+                  type="number"
+                  step="0.1"
+                  name="body_metric[body_fat_pct]"
+                  value={Phoenix.HTML.Form.input_value(@form, :body_fat_pct)}
+                  class="input input-bordered w-full"
+                  placeholder="e.g. 15.0"
+                />
+              </div>
+              <div class="form-control">
+                <label class="label"><span class="label-text">Chest (cm)</span></label>
+                <input
+                  type="number"
+                  step="0.1"
+                  name="body_metric[chest_cm]"
+                  value={Phoenix.HTML.Form.input_value(@form, :chest_cm)}
+                  class="input input-bordered w-full"
+                  placeholder="e.g. 100"
+                />
+              </div>
+              <div class="form-control">
+                <label class="label"><span class="label-text">Waist (cm)</span></label>
+                <input
+                  type="number"
+                  step="0.1"
+                  name="body_metric[waist_cm]"
+                  value={Phoenix.HTML.Form.input_value(@form, :waist_cm)}
+                  class="input input-bordered w-full"
+                  placeholder="e.g. 80"
+                />
+              </div>
+              <div class="form-control">
+                <label class="label"><span class="label-text">Hips (cm)</span></label>
+                <input
+                  type="number"
+                  step="0.1"
+                  name="body_metric[hips_cm]"
+                  value={Phoenix.HTML.Form.input_value(@form, :hips_cm)}
+                  class="input input-bordered w-full"
+                  placeholder="e.g. 95"
+                />
+              </div>
+              <div class="form-control">
+                <label class="label"><span class="label-text">Bicep (cm)</span></label>
+                <input
+                  type="number"
+                  step="0.1"
+                  name="body_metric[bicep_cm]"
+                  value={Phoenix.HTML.Form.input_value(@form, :bicep_cm)}
+                  class="input input-bordered w-full"
+                  placeholder="e.g. 35"
+                />
+              </div>
+              <div class="form-control">
+                <label class="label"><span class="label-text">Thigh (cm)</span></label>
+                <input
+                  type="number"
+                  step="0.1"
+                  name="body_metric[thigh_cm]"
+                  value={Phoenix.HTML.Form.input_value(@form, :thigh_cm)}
+                  class="input input-bordered w-full"
+                  placeholder="e.g. 55"
+                />
+              </div>
+            </div>
+            <div class="form-control">
+              <label class="label"><span class="label-text">Notes</span></label>
+              <textarea
+                name="body_metric[notes]"
+                class="textarea textarea-bordered w-full"
+                rows="2"
+                placeholder="Optional notes..."
+              >{Phoenix.HTML.Form.input_value(@form, :notes)}</textarea>
+            </div>
+
+            <%= for {field, {msg, _opts}} <- @form.errors do %>
+              <p class="text-error text-sm">{Phoenix.Naming.humanize(field)}: {msg}</p>
+            <% end %>
+
+            <div class="flex gap-2">
+              <button type="submit" class="btn btn-primary">
+                {if @editing, do: "Update", else: "Save"}
+              </button>
+              <%= if @editing do %>
+                <button type="button" phx-click="cancel_edit" class="btn btn-ghost">Cancel</button>
+              <% end %>
+            </div>
+          </form>
         </div>
 
         <%!-- Weight Chart --%>
@@ -93,6 +299,7 @@ defmodule GymStudioWeb.Trainer.ClientMetricsLive do
                     <th>Bicep</th>
                     <th>Thigh</th>
                     <th>Notes</th>
+                    <th>Actions</th>
                   </tr>
                 </thead>
                 <tbody>
@@ -107,6 +314,29 @@ defmodule GymStudioWeb.Trainer.ClientMetricsLive do
                       <td>{format_decimal(metric.bicep_cm)}</td>
                       <td>{format_decimal(metric.thigh_cm)}</td>
                       <td class="max-w-[200px] truncate">{metric.notes || "—"}</td>
+                      <td>
+                        <%= if trainer_logged?(metric, @trainer) do %>
+                          <div class="flex gap-1">
+                            <button
+                              phx-click="edit"
+                              phx-value-id={metric.id}
+                              class="btn btn-xs btn-ghost"
+                            >
+                              ✏️
+                            </button>
+                            <button
+                              phx-click="delete"
+                              phx-value-id={metric.id}
+                              data-confirm="Delete this entry?"
+                              class="btn btn-xs btn-ghost text-error"
+                            >
+                              🗑️
+                            </button>
+                          </div>
+                        <% else %>
+                          <span class="text-xs text-gray-400">Client entry</span>
+                        <% end %>
+                      </td>
                     </tr>
                   <% end %>
                 </tbody>

--- a/test/gym_studio_web/live/trainer/client_progress_live_test.exs
+++ b/test/gym_studio_web/live/trainer/client_progress_live_test.exs
@@ -5,6 +5,8 @@ defmodule GymStudioWeb.Trainer.ClientProgressLiveTest do
   import GymStudio.AccountsFixtures
   import GymStudio.SchedulingFixtures
 
+  alias GymStudio.{Goals, Metrics}
+
   setup do
     trainer_user = user_fixture(%{role: :trainer, name: "Coach Dan"})
     trainer = trainer_fixture(%{user_id: trainer_user.id})
@@ -52,7 +54,7 @@ defmodule GymStudioWeb.Trainer.ClientProgressLiveTest do
       assert html =~ "Goals"
     end
 
-    test "renders client metrics page", %{
+    test "renders client metrics page with form", %{
       conn: conn,
       trainer_user: trainer_user,
       client_user: client_user
@@ -62,11 +64,10 @@ defmodule GymStudioWeb.Trainer.ClientProgressLiveTest do
 
       assert html =~ "Alice Cooper&#39;s Body Metrics"
       assert html =~ "Back to Progress"
-      # No form for creating/editing (read-only)
-      refute html =~ "Log New Entry"
+      assert html =~ "Log New Entry"
     end
 
-    test "renders client goals page", %{
+    test "renders client goals page with form", %{
       conn: conn,
       trainer_user: trainer_user,
       client_user: client_user
@@ -76,8 +77,284 @@ defmodule GymStudioWeb.Trainer.ClientProgressLiveTest do
 
       assert html =~ "Alice Cooper&#39;s Goals"
       assert html =~ "Back to Progress"
-      # No form for creating goals (read-only)
-      refute html =~ "New Goal"
+      assert html =~ "New Goal"
+    end
+
+    # ── Metrics Write ────────────────────────────────────────────
+
+    test "trainer can create metric for client", %{
+      conn: conn,
+      trainer_user: trainer_user,
+      client_user: client_user
+    } do
+      conn = log_in_user(conn, trainer_user)
+      {:ok, view, _html} = live(conn, ~p"/trainer/clients/#{client_user.id}/progress/metrics")
+
+      view
+      |> form("form[phx-submit=save]", %{
+        "body_metric" => %{
+          "date" => "2025-01-15",
+          "weight_kg" => "80.5",
+          "body_fat_pct" => "18.0"
+        }
+      })
+      |> render_submit()
+
+      # Verify the metric was created with correct ownership
+      [metric] = Metrics.list_metrics(client_user.id)
+      assert metric.logged_by_id == trainer_user.id
+      assert metric.user_id == client_user.id
+      assert Decimal.equal?(metric.weight_kg, Decimal.new("80.5"))
+
+      # Verify it shows in the table
+      html = render(view)
+      assert html =~ "80.5"
+    end
+
+    test "trainer can edit metric they logged", %{
+      conn: conn,
+      trainer_user: trainer_user,
+      client_user: client_user
+    } do
+      {:ok, _metric} =
+        Metrics.create_metric(%{
+          "user_id" => client_user.id,
+          "logged_by_id" => trainer_user.id,
+          "date" => "2025-01-10",
+          "weight_kg" => "75.0"
+        })
+
+      conn = log_in_user(conn, trainer_user)
+      {:ok, view, _html} = live(conn, ~p"/trainer/clients/#{client_user.id}/progress/metrics")
+
+      # Click edit via event
+      render_click(view, "edit", %{"id" => hd(Metrics.list_metrics(client_user.id)).id})
+
+      view
+      |> form("form[phx-submit=save]", %{
+        "body_metric" => %{
+          "date" => "2025-01-10",
+          "weight_kg" => "76.0"
+        }
+      })
+      |> render_submit()
+
+      [metric] = Metrics.list_metrics(client_user.id)
+      assert Decimal.equal?(metric.weight_kg, Decimal.new("76.0"))
+    end
+
+    test "trainer cannot edit metric logged by client", %{
+      conn: conn,
+      trainer_user: trainer_user,
+      client_user: client_user
+    } do
+      {:ok, metric} =
+        Metrics.create_metric(%{
+          "user_id" => client_user.id,
+          "logged_by_id" => client_user.id,
+          "date" => "2025-01-10",
+          "weight_kg" => "75.0"
+        })
+
+      conn = log_in_user(conn, trainer_user)
+      {:ok, view, html} = live(conn, ~p"/trainer/clients/#{client_user.id}/progress/metrics")
+
+      # Should show "Client entry" instead of edit/delete buttons
+      assert html =~ "Client entry"
+
+      # Try to edit anyway via event — should be denied
+      render_click(view, "edit", %{"id" => metric.id})
+      # Verify form is NOT in edit mode (still shows "Log New Entry")
+      assert render(view) =~ "Log New Entry"
+    end
+
+    test "trainer can delete metric they logged", %{
+      conn: conn,
+      trainer_user: trainer_user,
+      client_user: client_user
+    } do
+      {:ok, metric} =
+        Metrics.create_metric(%{
+          "user_id" => client_user.id,
+          "logged_by_id" => trainer_user.id,
+          "date" => "2025-01-10",
+          "weight_kg" => "75.0"
+        })
+
+      conn = log_in_user(conn, trainer_user)
+      {:ok, view, _html} = live(conn, ~p"/trainer/clients/#{client_user.id}/progress/metrics")
+
+      render_click(view, "delete", %{"id" => metric.id})
+      assert Metrics.list_metrics(client_user.id) == []
+    end
+
+    test "trainer cannot delete metric logged by client", %{
+      conn: conn,
+      trainer_user: trainer_user,
+      client_user: client_user
+    } do
+      {:ok, metric} =
+        Metrics.create_metric(%{
+          "user_id" => client_user.id,
+          "logged_by_id" => client_user.id,
+          "date" => "2025-01-10",
+          "weight_kg" => "75.0"
+        })
+
+      conn = log_in_user(conn, trainer_user)
+      {:ok, view, _html} = live(conn, ~p"/trainer/clients/#{client_user.id}/progress/metrics")
+
+      render_click(view, "delete", %{"id" => metric.id})
+      # Metric should still exist — trainer can't delete client's entry
+      assert length(Metrics.list_metrics(client_user.id)) == 1
+    end
+
+    # ── Goals Write ──────────────────────────────────────────────
+
+    test "trainer can create goal for client", %{
+      conn: conn,
+      trainer_user: trainer_user,
+      client_user: client_user
+    } do
+      conn = log_in_user(conn, trainer_user)
+      {:ok, view, _html} = live(conn, ~p"/trainer/clients/#{client_user.id}/progress/goals")
+
+      view
+      |> form("form[phx-submit=save_goal]", %{
+        "fitness_goal" => %{
+          "title" => "Squat 120kg",
+          "target_value" => "120",
+          "target_unit" => "kg"
+        }
+      })
+      |> render_submit()
+
+      [goal] = Goals.list_goals(client_user.id)
+      assert goal.created_by_id == trainer_user.id
+      assert goal.client_id == client_user.id
+      assert goal.title == "Squat 120kg"
+
+      assert render(view) =~ "Squat 120kg"
+    end
+
+    test "trainer can update progress on client goal", %{
+      conn: conn,
+      trainer_user: trainer_user,
+      client_user: client_user
+    } do
+      {:ok, goal} =
+        Goals.create_goal(%{
+          "client_id" => client_user.id,
+          "created_by_id" => client_user.id,
+          "title" => "Run 5K",
+          "target_value" => "5",
+          "target_unit" => "kg"
+        })
+
+      conn = log_in_user(conn, trainer_user)
+      {:ok, view, _html} = live(conn, ~p"/trainer/clients/#{client_user.id}/progress/goals")
+
+      # Open progress editor
+      render_click(view, "edit_progress", %{"id" => goal.id})
+
+      view
+      |> form("form[phx-submit=save_progress]", %{
+        "goal_id" => goal.id,
+        "current_value" => "3"
+      })
+      |> render_submit()
+
+      updated = Goals.get_goal!(goal.id)
+      assert Decimal.equal?(updated.current_value, Decimal.new("3"))
+    end
+
+    test "trainer can achieve goal", %{
+      conn: conn,
+      trainer_user: trainer_user,
+      client_user: client_user
+    } do
+      {:ok, goal} =
+        Goals.create_goal(%{
+          "client_id" => client_user.id,
+          "created_by_id" => client_user.id,
+          "title" => "Run 5K",
+          "target_value" => "5",
+          "target_unit" => "kg"
+        })
+
+      conn = log_in_user(conn, trainer_user)
+      {:ok, view, _html} = live(conn, ~p"/trainer/clients/#{client_user.id}/progress/goals")
+
+      render_click(view, "achieve", %{"id" => goal.id})
+
+      updated = Goals.get_goal!(goal.id)
+      assert updated.status == "achieved"
+    end
+
+    test "trainer can abandon goal", %{
+      conn: conn,
+      trainer_user: trainer_user,
+      client_user: client_user
+    } do
+      {:ok, goal} =
+        Goals.create_goal(%{
+          "client_id" => client_user.id,
+          "created_by_id" => client_user.id,
+          "title" => "Run 5K",
+          "target_value" => "5",
+          "target_unit" => "kg"
+        })
+
+      conn = log_in_user(conn, trainer_user)
+      {:ok, view, _html} = live(conn, ~p"/trainer/clients/#{client_user.id}/progress/goals")
+
+      render_click(view, "abandon", %{"id" => goal.id})
+
+      updated = Goals.get_goal!(goal.id)
+      assert updated.status == "abandoned"
+    end
+
+    test "trainer can delete goal they created", %{
+      conn: conn,
+      trainer_user: trainer_user,
+      client_user: client_user
+    } do
+      {:ok, goal} =
+        Goals.create_goal(%{
+          "client_id" => client_user.id,
+          "created_by_id" => trainer_user.id,
+          "title" => "Trainer Goal",
+          "target_value" => "10",
+          "target_unit" => "kg"
+        })
+
+      conn = log_in_user(conn, trainer_user)
+      {:ok, view, _html} = live(conn, ~p"/trainer/clients/#{client_user.id}/progress/goals")
+
+      render_click(view, "delete", %{"id" => goal.id})
+      assert Goals.list_goals(client_user.id) == []
+    end
+
+    test "trainer cannot delete goal created by client", %{
+      conn: conn,
+      trainer_user: trainer_user,
+      client_user: client_user
+    } do
+      {:ok, goal} =
+        Goals.create_goal(%{
+          "client_id" => client_user.id,
+          "created_by_id" => client_user.id,
+          "title" => "Client Goal",
+          "target_value" => "10",
+          "target_unit" => "kg"
+        })
+
+      conn = log_in_user(conn, trainer_user)
+      {:ok, view, _html} = live(conn, ~p"/trainer/clients/#{client_user.id}/progress/goals")
+
+      render_click(view, "delete", %{"id" => goal.id})
+      # Goal should still exist — trainer can't delete client's goal
+      assert length(Goals.list_goals(client_user.id)) == 1
     end
   end
 


### PR DESCRIPTION
## Summary
Adds write capabilities to trainer client progress views (metrics + goals).

### Trainer Metrics Write
- Log New Entry form with logged_by_id = trainer
- Edit/delete restricted to trainer-logged entries only

### Trainer Goals Write
- New Goal form with created_by_id = trainer, client_id = client
- Update progress, achieve, abandon on any client goal
- Delete restricted to trainer-created goals only

### Tests
17 tests covering CRUD, ownership checks, and unauthorized access.

Closes #48