### PR TITLE
feat: Branches table + schema + seeds (#65)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Branches system — multi-location gym support (#65)
+  - `branches` table with name, slug, address, capacity, phone, coordinates, operating hours
+  - CRUD context (`GymStudio.Branches`) with slug-based lookups
+  - Slug is immutable after creation (prevents broken URLs)
+  - Unique index on slug for fast lookups
+  - Active/inactive branch filtering
+  - Seed data: React — Sin El Fil branch
+- Admin calendar: nil guard for sessions outside current week view
+- Calendar tests: navigate to correct week dynamically
+
+### Added
 - Initial Phoenix 1.8 application setup
 - User authentication system with email/password and magic links (phx.gen.auth)
 - User roles: client, trainer, admin

--- a/lib/gym_studio/branches.ex
+++ b/lib/gym_studio/branches.ex
@@ -25,6 +25,7 @@ defmodule GymStudio.Branches do
       iex> list_branches(active: true)
       [%Branch{}, ...]
   """
+  @spec list_branches(keyword()) :: [Branch.t()]
   def list_branches(opts \\ []) do
     query =
       if Keyword.has_key?(opts, :active) do
@@ -108,6 +109,10 @@ defmodule GymStudio.Branches do
 
   @doc """
   Deletes a branch.
+
+  > #### Warning {: .warning}
+  > Deleting a branch will fail with a foreign key constraint error once
+  > associations (e.g. sessions, trainers) are added in future issues.
 
   ## Examples
 

--- a/lib/gym_studio/branches.ex
+++ b/lib/gym_studio/branches.ex
@@ -1,0 +1,123 @@
+defmodule GymStudio.Branches do
+  @moduledoc """
+  The Branches context handles gym branch locations.
+
+  Provides CRUD operations for managing physical gym locations,
+  including listing, creating, updating, and deleting branches.
+  """
+
+  import Ecto.Query, warn: false
+  alias GymStudio.Repo
+  alias GymStudio.Branches.Branch
+
+  @doc """
+  Returns the list of branches.
+
+  ## Options
+
+    - `:active` - Filter by active status (true/false)
+
+  ## Examples
+
+      iex> list_branches()
+      [%Branch{}, ...]
+
+      iex> list_branches(active: true)
+      [%Branch{}, ...]
+  """
+  def list_branches(opts \\ []) do
+    query =
+      if Keyword.has_key?(opts, :active) do
+        where(Branch, [b], b.active == ^opts[:active])
+      else
+        Branch
+      end
+
+    query
+    |> order_by([b], asc: b.name)
+    |> Repo.all()
+  end
+
+  @doc """
+  Gets a single branch.
+
+  Raises `Ecto.NoResultsError` if the branch does not exist.
+
+  ## Examples
+
+      iex> get_branch!(1)
+      %Branch{}
+
+      iex> get_branch!(999)
+      ** (Ecto.NoResultsError)
+  """
+  def get_branch!(id) do
+    Repo.get!(Branch, id)
+  end
+
+  @doc """
+  Gets a branch by slug.
+
+  Returns `nil` if no branch is found.
+
+  ## Examples
+
+      iex> get_branch_by_slug("sin-el-fil")
+      %Branch{}
+
+      iex> get_branch_by_slug("nonexistent")
+      nil
+  """
+  def get_branch_by_slug(slug) do
+    Repo.get_by(Branch, slug: slug)
+  end
+
+  @doc """
+  Creates a branch.
+
+  ## Examples
+
+      iex> create_branch(%{name: "React — Sin El Fil", slug: "sin-el-fil", capacity: 4})
+      {:ok, %Branch{}}
+
+      iex> create_branch(%{name: nil})
+      {:error, %Ecto.Changeset{}}
+  """
+  def create_branch(attrs) do
+    %Branch{}
+    |> Branch.changeset(attrs)
+    |> Repo.insert()
+  end
+
+  @doc """
+  Updates a branch.
+
+  ## Examples
+
+      iex> update_branch(branch, %{capacity: 6})
+      {:ok, %Branch{}}
+
+      iex> update_branch(branch, %{capacity: -1})
+      {:error, %Ecto.Changeset{}}
+  """
+  def update_branch(%Branch{} = branch, attrs) do
+    branch
+    |> Branch.changeset(attrs)
+    |> Repo.update()
+  end
+
+  @doc """
+  Deletes a branch.
+
+  ## Examples
+
+      iex> delete_branch(branch)
+      {:ok, %Branch{}}
+
+      iex> delete_branch(branch)
+      {:error, %Ecto.Changeset{}}
+  """
+  def delete_branch(%Branch{} = branch) do
+    Repo.delete(branch)
+  end
+end

--- a/lib/gym_studio/branches.ex
+++ b/lib/gym_studio/branches.ex
@@ -103,7 +103,7 @@ defmodule GymStudio.Branches do
   """
   def update_branch(%Branch{} = branch, attrs) do
     branch
-    |> Branch.changeset(attrs)
+    |> Branch.update_changeset(attrs)
     |> Repo.update()
   end
 

--- a/lib/gym_studio/branches/branch.ex
+++ b/lib/gym_studio/branches/branch.ex
@@ -23,7 +23,9 @@ defmodule GymStudio.Branches.Branch do
   end
 
   @doc """
-  Changeset for creating and updating branches.
+  Changeset for creating branches.
+
+  Slug is immutable once set — use `update_changeset/2` for updates.
   """
   def changeset(branch, attrs) do
     branch
@@ -44,5 +46,26 @@ defmodule GymStudio.Branches.Branch do
     )
     |> validate_number(:capacity, greater_than: 0)
     |> unique_constraint(:slug)
+  end
+
+  @doc """
+  Changeset for updating branches.
+
+  Slug is excluded — it cannot be changed after creation.
+  """
+  def update_changeset(branch, attrs) do
+    branch
+    |> cast(attrs, [
+      :name,
+      :address,
+      :capacity,
+      :phone,
+      :latitude,
+      :longitude,
+      :operating_hours,
+      :active
+    ])
+    |> validate_required([:name, :capacity])
+    |> validate_number(:capacity, greater_than: 0)
   end
 end

--- a/lib/gym_studio/branches/branch.ex
+++ b/lib/gym_studio/branches/branch.ex
@@ -1,0 +1,49 @@
+defmodule GymStudio.Branches.Branch do
+  @moduledoc """
+  Schema for gym branch locations.
+
+  Each branch represents a physical gym location with its own capacity,
+  contact details, and operating hours.
+  """
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  @primary_key {:id, :id, autogenerate: true}
+  schema "branches" do
+    field :name, :string
+    field :slug, :string
+    field :address, :string
+    field :capacity, :integer
+    field :phone, :string
+    field :latitude, :float
+    field :longitude, :float
+    field :operating_hours, :map
+    field :active, :boolean, default: true
+
+    timestamps(type: :utc_datetime)
+  end
+
+  @doc """
+  Changeset for creating and updating branches.
+  """
+  def changeset(branch, attrs) do
+    branch
+    |> cast(attrs, [
+      :name,
+      :slug,
+      :address,
+      :capacity,
+      :phone,
+      :latitude,
+      :longitude,
+      :operating_hours,
+      :active
+    ])
+    |> validate_required([:name, :slug, :capacity])
+    |> validate_format(:slug, ~r/^[a-z0-9]+(?:-[a-z0-9]+)*$/,
+      message: "must be a valid slug (lowercase letters, numbers, and hyphens)"
+    )
+    |> validate_number(:capacity, greater_than: 0)
+    |> unique_constraint(:slug)
+  end
+end

--- a/lib/gym_studio/branches/branch.ex
+++ b/lib/gym_studio/branches/branch.ex
@@ -8,7 +8,6 @@ defmodule GymStudio.Branches.Branch do
   use Ecto.Schema
   import Ecto.Changeset
 
-  @primary_key {:id, :id, autogenerate: true}
   schema "branches" do
     field :name, :string
     field :slug, :string

--- a/lib/gym_studio_web/live/admin/calendar_live.ex
+++ b/lib/gym_studio_web/live/admin/calendar_live.ex
@@ -122,16 +122,21 @@ defmodule GymStudioWeb.Admin.CalendarLive do
   end
 
   def handle_event("show_session", %{"session-id" => session_id}, socket) do
-    session = find_session(socket.assigns.week_sessions, session_id)
+    case find_session(socket.assigns.week_sessions, session_id) do
+      nil ->
+        {:noreply, socket}
 
-    available_trainers =
-      if is_nil(session.trainer_id) do
-        Accounts.list_approved_trainers()
-      else
-        []
-      end
+      session ->
+        available_trainers =
+          if is_nil(session.trainer_id) do
+            Accounts.list_approved_trainers()
+          else
+            []
+          end
 
-    {:noreply, assign(socket, selected_session: session, available_trainers: available_trainers)}
+        {:noreply,
+         assign(socket, selected_session: session, available_trainers: available_trainers)}
+    end
   end
 
   def handle_event("close_modal", _params, socket) do

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule GymStudio.MixProject do
   def project do
     [
       app: :gym_studio,
-      version: "0.1.0",
+      version: "0.2.0",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/repo/migrations/20260411083019_create_branches.exs
+++ b/priv/repo/migrations/20260411083019_create_branches.exs
@@ -1,0 +1,21 @@
+defmodule GymStudio.Repo.Migrations.CreateBranches do
+  use Ecto.Migration
+
+  def change do
+    create table(:branches) do
+      add :name, :string, null: false
+      add :slug, :string, null: false
+      add :address, :text
+      add :capacity, :integer, null: false
+      add :phone, :string
+      add :latitude, :float
+      add :longitude, :float
+      add :operating_hours, :map
+      add :active, :boolean, default: true, null: false
+
+      timestamps(type: :utc_datetime)
+    end
+
+    create unique_index(:branches, [:slug])
+  end
+end

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -13,12 +13,53 @@
 alias GymStudio.Repo
 alias GymStudio.Accounts
 alias GymStudio.Accounts.{User, Trainer, Client}
+alias GymStudio.Branches
+alias GymStudio.Branches.Branch
 alias GymStudio.Packages
 alias GymStudio.Packages.SessionPackage
 alias GymStudio.Scheduling
 alias GymStudio.Scheduling.TrainingSession
 
 IO.puts("Seeding database...")
+
+# =============================================================================
+# BRANCHES
+# =============================================================================
+IO.puts("Creating branches...")
+
+{:ok, _sin_el_fil} =
+  Branches.create_branch(%{
+    name: "React — Sin El Fil",
+    slug: "sin-el-fil",
+    address: "Plot 274, Sin El Fil",
+    capacity: 4,
+    phone: "+961 1 234 567",
+    latitude: 33.8713,
+    longitude: 35.5297,
+    operating_hours: %{
+      mon: "06:00-22:00",
+      tue: "06:00-22:00",
+      wed: "06:00-22:00",
+      thu: "06:00-22:00",
+      fri: "06:00-22:00",
+      sat: "08:00-18:00",
+      sun: "10:00-16:00"
+    },
+    active: true
+  })
+
+IO.puts("  Branch created: React — Sin El Fil")
+
+{:ok, _other} =
+  Branches.create_branch(%{
+    name: "React — Other Branch",
+    slug: "other",
+    address: "TBD",
+    capacity: 6,
+    active: true
+  })
+
+IO.puts("  Branch created: React — Other Branch")
 
 # Helper function to create user with password
 defmodule SeedHelpers do

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -27,8 +27,10 @@ IO.puts("Seeding database...")
 # =============================================================================
 IO.puts("Creating branches...")
 
-{:ok, _sin_el_fil} =
-  Branches.create_branch(%{
+now = DateTime.utc_now() |> DateTime.truncate(:second)
+
+branch_seeds = [
+  %{
     name: "React — Sin El Fil",
     slug: "sin-el-fil",
     address: "Plot 274, Sin El Fil",
@@ -37,29 +39,36 @@ IO.puts("Creating branches...")
     latitude: 33.8713,
     longitude: 35.5297,
     operating_hours: %{
-      mon: "06:00-22:00",
-      tue: "06:00-22:00",
-      wed: "06:00-22:00",
-      thu: "06:00-22:00",
-      fri: "06:00-22:00",
-      sat: "08:00-18:00",
-      sun: "10:00-16:00"
+      "mon" => "06:00-22:00",
+      "tue" => "06:00-22:00",
+      "wed" => "06:00-22:00",
+      "thu" => "06:00-22:00",
+      "fri" => "06:00-22:00",
+      "sat" => "08:00-18:00",
+      "sun" => "10:00-16:00"
     },
-    active: true
-  })
-
-IO.puts("  Branch created: React — Sin El Fil")
-
-{:ok, _other} =
-  Branches.create_branch(%{
+    active: true,
+    inserted_at: now,
+    updated_at: now
+  },
+  %{
     name: "React — Other Branch",
     slug: "other",
     address: "TBD",
     capacity: 6,
-    active: true
-  })
+    active: true,
+    inserted_at: now,
+    updated_at: now
+  }
+]
 
-IO.puts("  Branch created: React — Other Branch")
+{count, _} = Repo.insert_all(Branch, branch_seeds, on_conflict: :nothing)
+
+if count > 0 do
+  IO.puts("  #{count} branch(es) created")
+else
+  IO.puts("  Branches already exist, skipping")
+end
 
 # Helper function to create user with password
 defmodule SeedHelpers do

--- a/test/gym_studio/branches_test.exs
+++ b/test/gym_studio/branches_test.exs
@@ -1,0 +1,198 @@
+defmodule GymStudio.BranchesTest do
+  use GymStudio.DataCase
+
+  alias GymStudio.Branches
+  alias GymStudio.Branches.Branch
+
+  describe "list_branches/1" do
+    test "returns all branches ordered by name" do
+      {:ok, _b1} = create_branch_fixture(%{name: "React — Z Branch", slug: "z-branch"})
+      {:ok, _b2} = create_branch_fixture(%{name: "React — A Branch", slug: "a-branch"})
+
+      branches = Branches.list_branches()
+      assert length(branches) == 2
+      assert hd(branches).name == "React — A Branch"
+    end
+
+    test "filters by active status" do
+      {:ok, _active} =
+        create_branch_fixture(%{name: "Active Branch", slug: "active", active: true})
+
+      {:ok, _inactive} =
+        create_branch_fixture(%{name: "Inactive Branch", slug: "inactive", active: false})
+
+      active = Branches.list_branches(active: true)
+      assert length(active) == 1
+      assert hd(active).slug == "active"
+
+      inactive = Branches.list_branches(active: false)
+      assert length(inactive) == 1
+      assert hd(inactive).slug == "inactive"
+    end
+
+    test "returns empty list when no branches exist" do
+      assert [] = Branches.list_branches()
+    end
+  end
+
+  describe "get_branch!/1" do
+    test "returns the branch with given id" do
+      {:ok, branch} = create_branch_fixture(%{name: "Test Branch", slug: "test-branch"})
+
+      retrieved = Branches.get_branch!(branch.id)
+      assert retrieved.id == branch.id
+      assert retrieved.name == "Test Branch"
+      assert retrieved.slug == "test-branch"
+    end
+
+    test "raises error with non-existent id" do
+      assert_raise Ecto.NoResultsError, fn ->
+        Branches.get_branch!(999_999)
+      end
+    end
+  end
+
+  describe "get_branch_by_slug/1" do
+    test "returns the branch with given slug" do
+      {:ok, branch} = create_branch_fixture(%{name: "Sin El Fil", slug: "sin-el-fil"})
+
+      retrieved = Branches.get_branch_by_slug("sin-el-fil")
+      assert retrieved.id == branch.id
+    end
+
+    test "returns nil for non-existent slug" do
+      assert nil == Branches.get_branch_by_slug("nonexistent")
+    end
+  end
+
+  describe "create_branch/1" do
+    test "creates a branch with valid attributes" do
+      attrs = %{
+        name: "React — Sin El Fil",
+        slug: "sin-el-fil",
+        address: "Plot 274, Sin El Fil",
+        capacity: 4,
+        phone: "+961 1 234 567",
+        latitude: 33.8713,
+        longitude: 35.5297,
+        operating_hours: %{
+          "mon" => "06:00-22:00",
+          "tue" => "06:00-22:00"
+        },
+        active: true
+      }
+
+      assert {:ok, %Branch{} = branch} = Branches.create_branch(attrs)
+      assert branch.name == "React — Sin El Fil"
+      assert branch.slug == "sin-el-fil"
+      assert branch.address == "Plot 274, Sin El Fil"
+      assert branch.capacity == 4
+      assert branch.phone == "+961 1 234 567"
+      assert branch.latitude == 33.8713
+      assert branch.longitude == 35.5297
+      assert branch.operating_hours["mon"] == "06:00-22:00"
+      assert branch.active == true
+    end
+
+    test "creates a branch with minimal attributes" do
+      attrs = %{name: "Minimal Branch", slug: "minimal", capacity: 10}
+
+      assert {:ok, %Branch{} = branch} = Branches.create_branch(attrs)
+      assert branch.name == "Minimal Branch"
+      assert branch.slug == "minimal"
+      assert branch.capacity == 10
+      assert branch.active == true
+      assert branch.address == nil
+      assert branch.phone == nil
+    end
+
+    test "returns error with missing required fields" do
+      attrs = %{name: "No Slug"}
+
+      assert {:error, changeset} = Branches.create_branch(attrs)
+      assert "can't be blank" in errors_on(changeset).slug
+      assert "can't be blank" in errors_on(changeset).capacity
+    end
+
+    test "returns error with invalid slug format" do
+      attrs = %{name: "Bad Slug", slug: "Invalid Slug!", capacity: 4}
+
+      assert {:error, changeset} = Branches.create_branch(attrs)
+
+      assert "must be a valid slug (lowercase letters, numbers, and hyphens)" in errors_on(
+               changeset
+             ).slug
+    end
+
+    test "returns error with duplicate slug" do
+      {:ok, _existing} = create_branch_fixture(%{name: "Existing", slug: "duplicate-slug"})
+
+      attrs = %{name: "New Branch", slug: "duplicate-slug", capacity: 6}
+
+      assert {:error, changeset} = Branches.create_branch(attrs)
+      assert "has already been taken" in errors_on(changeset).slug
+    end
+
+    test "returns error with zero or negative capacity" do
+      attrs = %{name: "Zero Cap", slug: "zero-cap", capacity: 0}
+
+      assert {:error, changeset} = Branches.create_branch(attrs)
+      assert "must be greater than 0" in errors_on(changeset).capacity
+
+      attrs2 = %{name: "Neg Cap", slug: "neg-cap", capacity: -1}
+
+      assert {:error, changeset2} = Branches.create_branch(attrs2)
+      assert "must be greater than 0" in errors_on(changeset2).capacity
+    end
+  end
+
+  describe "update_branch/2" do
+    test "updates a branch with valid attributes" do
+      {:ok, branch} =
+        create_branch_fixture(%{name: "Old Name", slug: "old-slug", capacity: 4})
+
+      assert {:ok, updated} = Branches.update_branch(branch, %{name: "New Name", capacity: 6})
+      assert updated.name == "New Name"
+      assert updated.capacity == 6
+      assert updated.slug == "old-slug"
+    end
+
+    test "returns error with invalid attributes" do
+      {:ok, branch} = create_branch_fixture(%{name: "Test", slug: "test", capacity: 4})
+
+      assert {:error, changeset} = Branches.update_branch(branch, %{capacity: -1})
+      assert "must be greater than 0" in errors_on(changeset).capacity
+    end
+
+    test "returns error when updating slug to existing one" do
+      {:ok, _b1} = create_branch_fixture(%{name: "Branch A", slug: "slug-a"})
+      {:ok, b2} = create_branch_fixture(%{name: "Branch B", slug: "slug-b"})
+
+      assert {:error, changeset} = Branches.update_branch(b2, %{slug: "slug-a"})
+      assert "has already been taken" in errors_on(changeset).slug
+    end
+  end
+
+  describe "delete_branch/1" do
+    test "deletes a branch" do
+      {:ok, branch} = create_branch_fixture(%{name: "To Delete", slug: "to-delete"})
+
+      assert {:ok, %Branch{}} = Branches.delete_branch(branch)
+
+      assert_raise Ecto.NoResultsError, fn ->
+        Branches.get_branch!(branch.id)
+      end
+    end
+  end
+
+  # Helper
+  defp create_branch_fixture(attrs) do
+    defaults = %{
+      name: "Test Branch",
+      slug: "test-branch-#{System.unique_integer([:positive])}",
+      capacity: 4
+    }
+
+    Branches.create_branch(Map.merge(defaults, Map.new(attrs)))
+  end
+end

--- a/test/gym_studio/branches_test.exs
+++ b/test/gym_studio/branches_test.exs
@@ -164,12 +164,13 @@ defmodule GymStudio.BranchesTest do
       assert "must be greater than 0" in errors_on(changeset).capacity
     end
 
-    test "returns error when updating slug to existing one" do
+    test "ignores slug changes — slug is immutable after creation" do
       {:ok, _b1} = create_branch_fixture(%{name: "Branch A", slug: "slug-a"})
       {:ok, b2} = create_branch_fixture(%{name: "Branch B", slug: "slug-b"})
 
-      assert {:error, changeset} = Branches.update_branch(b2, %{slug: "slug-a"})
-      assert "has already been taken" in errors_on(changeset).slug
+      # Attempting to update slug is silently ignored
+      assert {:ok, updated} = Branches.update_branch(b2, %{slug: "slug-a"})
+      assert updated.slug == "slug-b"
     end
   end
 

--- a/test/gym_studio_web/live/admin/calendar_live_test.exs
+++ b/test/gym_studio_web/live/admin/calendar_live_test.exs
@@ -47,7 +47,7 @@ defmodule GymStudioWeb.Admin.CalendarLiveTest do
       {:ok, view, _html} = live(conn, ~p"/admin/calendar")
 
       # Navigate to the week containing the session
-      render_click(view, "next_week")
+      navigate_to_week(view, tomorrow)
 
       # Open session modal — should show Unassigned badge
       html = render_click(view, "show_session", %{"session-id" => session.id})
@@ -76,8 +76,8 @@ defmodule GymStudioWeb.Admin.CalendarLiveTest do
       conn = log_in_user(conn, admin)
       {:ok, view, _html} = live(conn, ~p"/admin/calendar")
 
-      # Navigate to the week containing tomorrow
-      render_click(view, "next_week")
+      # Navigate to the week containing the session
+      navigate_to_week(view, tomorrow)
 
       # Open session modal
       render_click(view, "show_session", %{"session-id" => session.id})
@@ -95,6 +95,25 @@ defmodule GymStudioWeb.Admin.CalendarLiveTest do
       # Verify the session now has the trainer assigned
       updated = Scheduling.get_session!(session.id)
       assert updated.trainer_id == trainer.id
+    end
+  end
+
+  # Navigate the calendar to the week containing the target date
+  defp navigate_to_week(view, target_date) do
+    current_week_start = Date.beginning_of_week(Date.utc_today(), :monday)
+    target_week_start = Date.beginning_of_week(target_date, :monday)
+    diff_days = Date.diff(target_week_start, current_week_start)
+    weeks = div(diff_days, 7)
+
+    cond do
+      weeks > 0 ->
+        for _ <- 1..weeks, do: render_click(view, "next_week")
+
+      weeks < 0 ->
+        for _ <- 1..abs(weeks), do: render_click(view, "previous_week")
+
+      true ->
+        :ok
     end
   end
 end


### PR DESCRIPTION
## Summary

Implements GitHub issue #65 — Branches table + schema + seeds.

### What's included

- **Migration**: branches table with id, name, slug (unique), address, capacity, phone, latitude, longitude, operating_hours (JSONB), active, and timestamps
- **Schema**: GymStudio.Branches.Branch with changeset validation (required fields, slug format, capacity > 0, unique slug constraint)
- **Context**: GymStudio.Branches with list_branches/1, get_branch!/1, get_branch_by_slug/1, create_branch/1, update_branch/2, delete_branch/1
- **Seeds**: Two branches — React - Sin El Fil (slug: sin-el-fil, capacity: 4) and React - Other Branch (slug: other, capacity: 6, address: TBD)
- **Tests**: 17 tests covering all CRUD operations, validation, slug uniqueness, active filter

### Not included (per issue scope)

- No branch_id added to other tables yet (separate PR)
- No LiveView UI for branches

### Bug fix discovered

- list_branches(active: false) was broken because if active = opts[:active] treats false as falsy. Fixed by using Keyword.has_key?(opts, :active).

Closes #65
