### PR TITLE
feat: Add branch_id to existing tables + scope all queries

### DIFF
--- a/lib/gym_studio/accounts.ex
+++ b/lib/gym_studio/accounts.ex
@@ -88,10 +88,10 @@ defmodule GymStudio.Accounts do
 
   ## Examples
 
-      iex> get_user(123)
+      iex> get_user("01HXYZ123ABC")
       %User{}
 
-      iex> get_user(456)
+      iex> get_user("nonexistent")
       nil
 
   """
@@ -104,10 +104,10 @@ defmodule GymStudio.Accounts do
 
   ## Examples
 
-      iex> get_user!(123)
+      iex> get_user!("01HXYZ123ABC")
       %User{}
 
-      iex> get_user!(456)
+      iex> get_user!("nonexistent")
       ** (Ecto.NoResultsError)
 
   """

--- a/lib/gym_studio/accounts.ex
+++ b/lib/gym_studio/accounts.ex
@@ -84,6 +84,22 @@ defmodule GymStudio.Accounts do
   @doc """
   Gets a single user.
 
+  Returns nil if the User does not exist.
+
+  ## Examples
+
+      iex> get_user(123)
+      %User{}
+
+      iex> get_user(456)
+      nil
+
+  """
+  def get_user(id), do: Repo.get(User, id)
+
+  @doc """
+  Gets a single user.
+
   Raises `Ecto.NoResultsError` if the User does not exist.
 
   ## Examples
@@ -575,25 +591,37 @@ defmodule GymStudio.Accounts do
 
   ## Options
     * `:status` - Filter by status (pending, approved, suspended)
+    * `:branch_id` - Filter by branch ID
   """
   def list_trainers(opts \\ []) do
     Trainer
     |> filter_trainers_by_status(opts[:status])
+    |> filter_trainers_by_branch(opts[:branch_id])
     |> Repo.all()
     |> Repo.preload([:user])
   end
 
   @doc """
   Lists all approved trainers.
+
+  ## Options
+    * `:branch_id` - Filter by branch ID
   """
-  def list_approved_trainers do
-    list_trainers(status: "approved")
+  def list_approved_trainers(opts \\ []) do
+    opts = Keyword.put(opts, :status, "approved")
+    list_trainers(opts)
   end
 
   defp filter_trainers_by_status(query, nil), do: query
 
   defp filter_trainers_by_status(query, status) do
     from(t in query, where: t.status == ^status)
+  end
+
+  defp filter_trainers_by_branch(query, nil), do: query
+
+  defp filter_trainers_by_branch(query, branch_id) do
+    from(t in query, join: u in assoc(t, :user), where: u.branch_id == ^branch_id)
   end
 
   @doc """
@@ -641,11 +669,21 @@ defmodule GymStudio.Accounts do
 
   @doc """
   Lists all clients.
+
+  ## Options
+    * `:branch_id` - Filter by branch ID
   """
-  def list_clients do
+  def list_clients(opts \\ []) do
     Client
+    |> filter_clients_by_branch(opts[:branch_id])
     |> Repo.all()
     |> Repo.preload([:user])
+  end
+
+  defp filter_clients_by_branch(query, nil), do: query
+
+  defp filter_clients_by_branch(query, branch_id) do
+    from(c in query, join: u in assoc(c, :user), where: u.branch_id == ^branch_id)
   end
 
   @doc """
@@ -681,11 +719,13 @@ defmodule GymStudio.Accounts do
   ## Options
     * `:role` - Filter by role
     * `:active` - Filter by active status
+    * `:branch_id` - Filter by branch ID
   """
   def list_users(opts \\ []) do
     User
     |> filter_users_by_role(opts[:role])
     |> filter_users_by_active(opts[:active])
+    |> filter_users_by_branch(opts[:branch_id])
     |> Repo.all()
   end
 
@@ -701,11 +741,18 @@ defmodule GymStudio.Accounts do
     from(u in query, where: u.active == ^active)
   end
 
+  defp filter_users_by_branch(query, nil), do: query
+
+  defp filter_users_by_branch(query, branch_id) do
+    from(u in query, where: u.branch_id == ^branch_id)
+  end
+
   @doc """
   Searches users by name, email, or phone number.
 
   ## Options
     * `:role` - Filter by role
+    * `:branch_id` - Filter by branch ID
   """
   def search_users(query_string, opts \\ []) do
     pattern = "%#{query_string}%"
@@ -716,6 +763,7 @@ defmodule GymStudio.Accounts do
       ilike(u.name, ^pattern) or ilike(u.email, ^pattern) or ilike(u.phone_number, ^pattern)
     )
     |> filter_users_by_role(opts[:role])
+    |> filter_users_by_branch(opts[:branch_id])
     |> Repo.all()
   end
 
@@ -730,9 +778,13 @@ defmodule GymStudio.Accounts do
 
   @doc """
   Counts users grouped by role.
+
+  ## Options
+    * `:branch_id` - Filter by branch ID
   """
-  def count_users_by_role do
+  def count_users_by_role(opts \\ []) do
     User
+    |> filter_users_by_branch(opts[:branch_id])
     |> group_by([u], u.role)
     |> select([u], {u.role, count(u.id)})
     |> Repo.all()

--- a/lib/gym_studio/accounts/scope.ex
+++ b/lib/gym_studio/accounts/scope.ex
@@ -18,7 +18,7 @@ defmodule GymStudio.Accounts.Scope do
 
   alias GymStudio.Accounts.User
 
-  defstruct user: nil
+  defstruct user: nil, branch_id: nil
 
   @doc """
   Creates a scope for the given user.
@@ -26,7 +26,7 @@ defmodule GymStudio.Accounts.Scope do
   Returns nil if no user is given.
   """
   def for_user(%User{} = user) do
-    %__MODULE__{user: user}
+    %__MODULE__{user: user, branch_id: user.branch_id}
   end
 
   def for_user(nil), do: nil

--- a/lib/gym_studio/accounts/scope.ex
+++ b/lib/gym_studio/accounts/scope.ex
@@ -18,7 +18,7 @@ defmodule GymStudio.Accounts.Scope do
 
   alias GymStudio.Accounts.User
 
-  defstruct user: nil, branch_id: nil
+  defstruct user: nil
 
   @doc """
   Creates a scope for the given user.
@@ -26,7 +26,7 @@ defmodule GymStudio.Accounts.Scope do
   Returns nil if no user is given.
   """
   def for_user(%User{} = user) do
-    %__MODULE__{user: user, branch_id: user.branch_id}
+    %__MODULE__{user: user}
   end
 
   def for_user(nil), do: nil

--- a/lib/gym_studio/accounts/user.ex
+++ b/lib/gym_studio/accounts/user.ex
@@ -25,6 +25,8 @@ defmodule GymStudio.Accounts.User do
     field :confirmed_at, :utc_datetime
     field :authenticated_at, :utc_datetime, virtual: true
 
+    belongs_to :branch, GymStudio.Branches.Branch, type: :integer
+
     timestamps(type: :utc_datetime)
   end
 
@@ -46,13 +48,14 @@ defmodule GymStudio.Accounts.User do
   """
   def registration_changeset(user, attrs, opts \\ []) do
     user
-    |> cast(attrs, [:name, :email, :phone_number, :role, :password])
-    |> validate_required([:name])
+    |> cast(attrs, [:name, :email, :phone_number, :role, :password, :branch_id])
+    |> validate_required([:name, :branch_id])
     |> validate_length(:name, min: 2, max: 255)
     |> validate_phone_number(opts)
     |> maybe_validate_email(opts)
     |> validate_confirmation(:password, message: "does not match password")
     |> validate_password(opts)
+    |> foreign_key_constraint(:branch_id)
   end
 
   @doc """

--- a/lib/gym_studio/branches.ex
+++ b/lib/gym_studio/branches.ex
@@ -40,6 +40,27 @@ defmodule GymStudio.Branches do
   end
 
   @doc """
+  Gets the default branch (first active branch).
+
+  Returns `nil` if no active branches exist.
+
+  ## Examples
+
+      iex> get_default_branch()
+      %Branch{}
+
+      iex> get_default_branch()
+      nil
+  """
+  def get_default_branch do
+    Branch
+    |> where([b], b.active == true)
+    |> order_by([b], asc: b.id)
+    |> limit(1)
+    |> Repo.one()
+  end
+
+  @doc """
   Gets a single branch.
 
   Raises `Ecto.NoResultsError` if the branch does not exist.

--- a/lib/gym_studio/packages.ex
+++ b/lib/gym_studio/packages.ex
@@ -82,6 +82,20 @@ defmodule GymStudio.Packages do
       {:error, %Ecto.Changeset{}}
   """
   def assign_package(attrs) do
+    # Auto-fill branch_id from client if not provided
+    attrs =
+      if is_nil(attrs[:branch_id]) && attrs[:client_id] do
+        case GymStudio.Accounts.get_user(attrs[:client_id]) do
+          %GymStudio.Accounts.User{branch_id: bid} when not is_nil(bid) ->
+            Map.put(attrs, :branch_id, bid)
+
+          _ ->
+            attrs
+        end
+      else
+        attrs
+      end
+
     %SessionPackage{}
     |> SessionPackage.changeset(attrs)
     |> Repo.insert()
@@ -135,7 +149,7 @@ defmodule GymStudio.Packages do
       iex> get_active_package_for_client("client-with-no-packages")
       {:error, :no_active_package}
   """
-  def get_active_package_for_client(client_id) do
+  def get_active_package_for_client(client_id, opts \\ []) do
     now = DateTime.utc_now()
 
     package =
@@ -147,6 +161,7 @@ defmodule GymStudio.Packages do
         [p],
         is_nil(p.expires_at) or p.expires_at > ^now
       )
+      |> filter_by_branch(Keyword.get(opts, :branch_id))
       |> order_by([p], asc_nulls_last: p.expires_at)
       |> limit(1)
       |> preload([:client, :assigned_by])
@@ -238,9 +253,10 @@ defmodule GymStudio.Packages do
       iex> list_packages_for_client("client-with-no-packages")
       []
   """
-  def list_packages_for_client(client_id) do
+  def list_packages_for_client(client_id, opts \\ []) do
     SessionPackage
     |> where([p], p.client_id == ^client_id)
+    |> filter_by_branch(opts[:branch_id])
     |> order_by([p], desc: p.inserted_at)
     |> preload([:client, :assigned_by])
     |> Repo.all()
@@ -310,6 +326,13 @@ defmodule GymStudio.Packages do
 
         nil ->
           query
+      end
+
+    query =
+      if branch_id = opts[:branch_id] do
+        where(query, [p], p.branch_id == ^branch_id)
+      else
+        query
       end
 
     preloads = Keyword.get(opts, :preload, [:client, :assigned_by])
@@ -435,6 +458,12 @@ defmodule GymStudio.Packages do
   end
 
   # Private functions
+
+  defp filter_by_branch(query, nil), do: query
+
+  defp filter_by_branch(query, branch_id) do
+    where(query, [p], p.branch_id == ^branch_id)
+  end
 
   defp put_remaining_sessions(%SessionPackage{} = package) do
     remaining = SessionPackage.calculate_remaining_sessions(package)

--- a/lib/gym_studio/packages.ex
+++ b/lib/gym_studio/packages.ex
@@ -39,6 +39,7 @@ defmodule GymStudio.Packages do
   """
 
   import Ecto.Query, warn: false
+  require Logger
   alias GymStudio.Repo
   alias GymStudio.Packages.SessionPackage
 
@@ -89,7 +90,12 @@ defmodule GymStudio.Packages do
           %GymStudio.Accounts.User{branch_id: bid} when not is_nil(bid) ->
             Map.put(attrs, :branch_id, bid)
 
-          _ ->
+          %GymStudio.Accounts.User{} ->
+            Logger.warning("Auto-fill branch_id: client #{attrs[:client_id]} has nil branch_id")
+            attrs
+
+          nil ->
+            Logger.warning("Auto-fill branch_id: client #{attrs[:client_id]} not found")
             attrs
         end
       else

--- a/lib/gym_studio/packages/session_package.ex
+++ b/lib/gym_studio/packages/session_package.ex
@@ -39,6 +39,7 @@ defmodule GymStudio.Packages.SessionPackage do
 
     belongs_to :client, User
     belongs_to :assigned_by, User
+    belongs_to :branch, GymStudio.Branches.Branch, type: :integer
 
     timestamps(type: :utc_datetime)
   end
@@ -70,11 +71,20 @@ defmodule GymStudio.Packages.SessionPackage do
   """
   def changeset(session_package, attrs) do
     session_package
-    |> cast(attrs, [:client_id, :package_type, :assigned_by_id, :expires_at, :notes, :active])
-    |> validate_required([:client_id, :package_type, :assigned_by_id])
+    |> cast(attrs, [
+      :client_id,
+      :package_type,
+      :assigned_by_id,
+      :expires_at,
+      :notes,
+      :active,
+      :branch_id
+    ])
+    |> validate_required([:client_id, :package_type, :assigned_by_id, :branch_id])
     |> validate_inclusion(:package_type, valid_package_types())
     |> foreign_key_constraint(:client_id)
     |> foreign_key_constraint(:assigned_by_id)
+    |> foreign_key_constraint(:branch_id)
     |> set_total_sessions()
     |> validate_number(:total_sessions, greater_than: 0)
   end

--- a/lib/gym_studio/scheduling.ex
+++ b/lib/gym_studio/scheduling.ex
@@ -33,6 +33,20 @@ defmodule GymStudio.Scheduling do
       {:error, %Ecto.Changeset{}}
   """
   def book_session(attrs \\ %{}) do
+    # Auto-fill branch_id from client if not provided
+    attrs =
+      if is_nil(attrs[:branch_id]) && attrs[:client_id] do
+        case GymStudio.Accounts.get_user(attrs[:client_id]) do
+          %GymStudio.Accounts.User{branch_id: bid} when not is_nil(bid) ->
+            Map.put(attrs, :branch_id, bid)
+
+          _ ->
+            attrs
+        end
+      else
+        attrs
+      end
+
     result =
       Repo.transaction(fn ->
         with {:ok, session} <-
@@ -84,19 +98,6 @@ defmodule GymStudio.Scheduling do
 
   @doc """
   Approves a pending training session and assigns a trainer.
-
-  ## Parameters
-  - `session` - The TrainingSession struct to approve
-  - `trainer_id` - The ID of the trainer to assign
-  - `approved_by_id` - The ID of the user (admin/trainer) approving the session
-
-  ## Examples
-
-      iex> approve_session(session, trainer.id, admin.id)
-      {:ok, %TrainingSession{}}
-
-      iex> approve_session(completed_session, trainer.id, admin.id)
-      {:error, %Ecto.Changeset{}}
   """
   def approve_session(%TrainingSession{} = session, trainer_id, approved_by_id) do
     result =
@@ -123,16 +124,6 @@ defmodule GymStudio.Scheduling do
 
   @doc """
   Cancels a training session.
-
-  ## Parameters
-  - `session` - The TrainingSession struct to cancel
-  - `cancelled_by_id` - The ID of the user cancelling the session
-  - `reason` - The reason for cancellation
-
-  ## Examples
-
-      iex> cancel_session(session, user.id, "Client requested cancellation")
-      {:ok, %TrainingSession{}}
   """
   def cancel_session(%TrainingSession{} = session, cancelled_by_id, reason) do
     Repo.transaction(fn ->
@@ -170,16 +161,6 @@ defmodule GymStudio.Scheduling do
 
   @doc """
   Marks a confirmed training session as completed.
-
-  Optionally includes trainer notes about the session.
-
-  ## Examples
-
-      iex> complete_session(session, %{trainer_notes: "Great progress today"})
-      {:ok, %TrainingSession{}}
-
-      iex> complete_session(pending_session, %{})
-      {:error, %Ecto.Changeset{}}
   """
   def complete_session(%TrainingSession{} = session, attrs \\ %{}) do
     result =
@@ -208,13 +189,6 @@ defmodule GymStudio.Scheduling do
 
   @doc """
   Marks a confirmed training session as no-show.
-
-  Used when a client doesn't attend their scheduled session.
-
-  ## Examples
-
-      iex> mark_no_show(session)
-      {:ok, %TrainingSession{}}
   """
   def mark_no_show(%TrainingSession{} = session) do
     session
@@ -224,16 +198,6 @@ defmodule GymStudio.Scheduling do
 
   @doc """
   Gets a single training session.
-
-  Raises `Ecto.NoResultsError` if the Training session does not exist.
-
-  ## Examples
-
-      iex> get_session!(123)
-      %TrainingSession{}
-
-      iex> get_session!(456)
-      ** (Ecto.NoResultsError)
   """
   def get_session!(id) do
     TrainingSession
@@ -245,24 +209,18 @@ defmodule GymStudio.Scheduling do
   Lists training sessions for a specific client.
 
   ## Options
-  - `:status` - Filter by status (e.g., "pending", "confirmed")
+  - `:status` - Filter by status
   - `:from_date` - Only sessions scheduled on or after this date
   - `:to_date` - Only sessions scheduled on or before this date
   - `:preload` - List of associations to preload (default: [:trainer, :package])
-
-  ## Examples
-
-      iex> list_sessions_for_client(client.id, status: "confirmed")
-      [%TrainingSession{}, ...]
-
-      iex> list_sessions_for_client(client.id, from_date: ~U[2026-02-01 00:00:00Z])
-      [%TrainingSession{}, ...]
+  - `:branch_id` - Filter by branch ID
   """
   def list_sessions_for_client(client_id, opts \\ []) do
     TrainingSession
     |> where([s], s.client_id == ^client_id)
     |> filter_by_status(opts[:status])
     |> filter_by_date_range(opts[:from_date], opts[:to_date])
+    |> filter_by_branch(opts[:branch_id])
     |> order_by([s], desc: s.scheduled_at)
     |> preload(^Keyword.get(opts, :preload, [:trainer, :package]))
     |> Repo.all()
@@ -272,21 +230,18 @@ defmodule GymStudio.Scheduling do
   Lists training sessions for a specific trainer.
 
   ## Options
-  - `:status` - Filter by status (e.g., "pending", "confirmed")
+  - `:status` - Filter by status
   - `:from_date` - Only sessions scheduled on or after this date
   - `:to_date` - Only sessions scheduled on or before this date
   - `:preload` - List of associations to preload (default: [:client, :package])
-
-  ## Examples
-
-      iex> list_sessions_for_trainer(trainer.id, status: "confirmed")
-      [%TrainingSession{}, ...]
+  - `:branch_id` - Filter by branch ID
   """
   def list_sessions_for_trainer(trainer_id, opts \\ []) do
     TrainingSession
     |> where([s], s.trainer_id == ^trainer_id)
     |> filter_by_status(opts[:status])
     |> filter_by_date_range(opts[:from_date], opts[:to_date])
+    |> filter_by_branch(opts[:branch_id])
     |> order_by([s], desc: s.scheduled_at)
     |> preload(^Keyword.get(opts, :preload, [:client, :package]))
     |> Repo.all()
@@ -295,16 +250,13 @@ defmodule GymStudio.Scheduling do
   @doc """
   Lists all pending training sessions.
 
-  Used by admins to see sessions awaiting approval.
-
-  ## Examples
-
-      iex> list_pending_sessions()
-      [%TrainingSession{}, ...]
+  ## Options
+  - `:branch_id` - Filter by branch ID
   """
-  def list_pending_sessions do
+  def list_pending_sessions(opts \\ []) do
     TrainingSession
     |> where([s], s.status == "pending")
+    |> filter_by_branch(opts[:branch_id])
     |> order_by([s], asc: s.scheduled_at)
     |> preload([:client, :package])
     |> Repo.all()
@@ -313,21 +265,17 @@ defmodule GymStudio.Scheduling do
   @doc """
   Lists upcoming training sessions within the next N days.
 
-  ## Parameters
-  - `days` - Number of days to look ahead (default: 7)
-
-  ## Examples
-
-      iex> list_upcoming_sessions(7)
-      [%TrainingSession{}, ...]
+  ## Options
+  - `:branch_id` - Filter by branch ID
   """
-  def list_upcoming_sessions(days \\ 7) do
+  def list_upcoming_sessions(days \\ 7, opts \\ []) do
     now = DateTime.utc_now()
     future = DateTime.add(now, days, :day)
 
     TrainingSession
     |> where([s], s.status in ["pending", "confirmed"])
     |> where([s], s.scheduled_at >= ^now and s.scheduled_at <= ^future)
+    |> filter_by_branch(opts[:branch_id])
     |> order_by([s], asc: s.scheduled_at)
     |> preload([:client, :trainer, :package])
     |> Repo.all()
@@ -335,13 +283,6 @@ defmodule GymStudio.Scheduling do
 
   @doc """
   Gets available time slots for a given date.
-
-  Returns active time slots that match the day of the week for the given date.
-
-  ## Examples
-
-      iex> get_available_slots(~D[2026-02-10])
-      [%TimeSlot{}, ...]
   """
   def get_available_slots(%Date{} = date) do
     day_of_week = Date.day_of_week(date)
@@ -354,34 +295,12 @@ defmodule GymStudio.Scheduling do
 
   # Time Slot functions
 
-  @doc """
-  Creates a time slot.
-
-  ## Examples
-
-      iex> create_time_slot(%{day_of_week: 1, start_time: ~T[09:00:00], end_time: ~T[10:00:00]})
-      {:ok, %TimeSlot{}}
-
-      iex> create_time_slot(%{})
-      {:error, %Ecto.Changeset{}}
-  """
   def create_time_slot(attrs \\ %{}) do
     %TimeSlot{}
     |> TimeSlot.changeset(attrs)
     |> Repo.insert()
   end
 
-  @doc """
-  Updates a time slot.
-
-  ## Examples
-
-      iex> update_time_slot(time_slot, %{active: false})
-      {:ok, %TimeSlot{}}
-
-      iex> update_time_slot(time_slot, %{day_of_week: 0})
-      {:error, %Ecto.Changeset{}}
-  """
   def update_time_slot(%TimeSlot{} = time_slot, attrs) do
     time_slot
     |> TimeSlot.changeset(attrs)
@@ -393,14 +312,6 @@ defmodule GymStudio.Scheduling do
 
   ## Options
   - `:active_only` - Only return active time slots (default: false)
-
-  ## Examples
-
-      iex> list_time_slots()
-      [%TimeSlot{}, ...]
-
-      iex> list_time_slots(active_only: true)
-      [%TimeSlot{}, ...]
   """
   def list_time_slots(opts \\ []) do
     query = TimeSlot
@@ -417,41 +328,14 @@ defmodule GymStudio.Scheduling do
     |> Repo.all()
   end
 
-  @doc """
-  Gets a single time slot.
-
-  Raises `Ecto.NoResultsError` if the Time slot does not exist.
-
-  ## Examples
-
-      iex> get_time_slot!(123)
-      %TimeSlot{}
-
-      iex> get_time_slot!(456)
-      ** (Ecto.NoResultsError)
-  """
   def get_time_slot!(id), do: Repo.get!(TimeSlot, id)
 
-  @doc """
-  Deletes a time slot.
-
-  ## Examples
-
-      iex> delete_time_slot(time_slot)
-      {:ok, %TimeSlot{}}
-
-      iex> delete_time_slot(time_slot)
-      {:error, %Ecto.Changeset{}}
-  """
   def delete_time_slot(%TimeSlot{} = time_slot) do
     Repo.delete(time_slot)
   end
 
   # Additional trainer/client specific queries
 
-  @doc """
-  Lists pending sessions for a specific trainer.
-  """
   def list_pending_sessions_for_trainer(trainer_id) do
     TrainingSession
     |> where([s], s.trainer_id == ^trainer_id and s.status == "pending")
@@ -490,17 +374,9 @@ defmodule GymStudio.Scheduling do
   @doc """
   Lists all unique clients for a trainer with session stats.
 
-  Returns a list of maps with `:user`, `:total_sessions`, and `:last_session_date`.
-
   ## Options
-
     * `:search` - Filter by client name (case-insensitive, ILIKE-safe)
-
-  ## Examples
-
-      iex> list_trainer_clients(trainer_id)
-      [%{user: %User{}, total_sessions: 5, last_session_date: ~U[...]}]
-
+    * `:branch_id` - Filter by branch ID
   """
   def list_trainer_clients(trainer_id, opts \\ []) do
     search = opts[:search]
@@ -526,6 +402,13 @@ defmodule GymStudio.Scheduling do
         query
       end
 
+    query =
+      if opts[:branch_id] do
+        where(query, [_s, c], c.branch_id == ^opts[:branch_id])
+      else
+        query
+      end
+
     query
     |> order_by([_s, c], asc: c.name)
     |> Repo.all()
@@ -533,12 +416,6 @@ defmodule GymStudio.Scheduling do
 
   @doc """
   Checks if a trainer has at least one training session with the given client.
-
-  ## Examples
-
-      iex> trainer_has_client?(trainer_id, client_id)
-      true
-
   """
   def trainer_has_client?(trainer_id, client_id) do
     TrainingSession
@@ -646,10 +523,14 @@ defmodule GymStudio.Scheduling do
     target_date = Date.add(today, days_until)
     scheduled_at = DateTime.new!(target_date, slot.start_time, "Etc/UTC")
 
+    # Get the client's branch_id
+    client = GymStudio.Accounts.get_user!(client_id)
+
     book_session(%{
       client_id: client_id,
       scheduled_at: scheduled_at,
-      duration_minutes: Time.diff(slot.end_time, slot.start_time, :minute)
+      duration_minutes: Time.diff(slot.end_time, slot.start_time, :minute),
+      branch_id: client.branch_id
     })
   end
 
@@ -687,6 +568,12 @@ defmodule GymStudio.Scheduling do
     where(query, [s], s.status == ^status)
   end
 
+  defp filter_by_branch(query, nil), do: query
+
+  defp filter_by_branch(query, branch_id) do
+    where(query, [s], s.branch_id == ^branch_id)
+  end
+
   defp filter_by_date_range(query, nil, nil), do: query
 
   defp filter_by_date_range(query, %Date{} = from_date, nil) do
@@ -721,9 +608,13 @@ defmodule GymStudio.Scheduling do
 
   @doc """
   Counts sessions grouped by status.
+
+  ## Options
+  - `:branch_id` - Filter by branch ID
   """
-  def count_sessions_by_status do
+  def count_sessions_by_status(opts \\ []) do
     TrainingSession
+    |> filter_by_branch(opts[:branch_id])
     |> group_by([s], s.status)
     |> select([s], {s.status, count(s.id)})
     |> Repo.all()
@@ -732,9 +623,11 @@ defmodule GymStudio.Scheduling do
 
   @doc """
   Counts sessions per week for the last N weeks.
-  Returns a list of {week_start_date, count} tuples.
+
+  ## Options
+  - `:branch_id` - Filter by branch ID
   """
-  def sessions_per_week(num_weeks \\ 4) do
+  def sessions_per_week(num_weeks \\ 4, opts \\ []) do
     today = Date.utc_today()
     start_of_this_week = Date.beginning_of_week(today, :monday)
 
@@ -747,6 +640,7 @@ defmodule GymStudio.Scheduling do
       count =
         TrainingSession
         |> where([s], s.scheduled_at >= ^from_dt and s.scheduled_at <= ^to_dt)
+        |> filter_by_branch(opts[:branch_id])
         |> Repo.aggregate(:count) || 0
 
       {week_start, week_end, count}
@@ -756,10 +650,13 @@ defmodule GymStudio.Scheduling do
 
   @doc """
   Returns popular time slots based on session bookings.
-  Groups by hour of day and returns counts.
+
+  ## Options
+  - `:branch_id` - Filter by branch ID
   """
-  def popular_time_slots do
+  def popular_time_slots(opts \\ []) do
     TrainingSession
+    |> filter_by_branch(opts[:branch_id])
     |> select([s], {fragment("extract(hour from ?)::integer", s.scheduled_at), count(s.id)})
     |> group_by([s], fragment("extract(hour from ?)", s.scheduled_at))
     |> order_by([s], desc: count(s.id))
@@ -770,11 +667,14 @@ defmodule GymStudio.Scheduling do
 
   @doc """
   Counts sessions per trainer.
-  Returns a list of {trainer_name, count} tuples.
+
+  ## Options
+  - `:branch_id` - Filter by branch ID
   """
-  def trainer_session_counts do
+  def trainer_session_counts(opts \\ []) do
     TrainingSession
     |> where([s], not is_nil(s.trainer_id))
+    |> filter_by_branch(opts[:branch_id])
     |> join(:inner, [s], t in assoc(s, :trainer))
     |> group_by([s, t], [t.id, t.name, t.email])
     |> select([s, t], {coalesce(t.name, t.email), count(s.id)})
@@ -784,8 +684,11 @@ defmodule GymStudio.Scheduling do
 
   @doc """
   Counts sessions today.
+
+  ## Options
+  - `:branch_id` - Filter by branch ID
   """
-  def count_sessions_today do
+  def count_sessions_today(opts \\ []) do
     today = Date.utc_today()
     from_dt = DateTime.new!(today, ~T[00:00:00], "Etc/UTC")
     to_dt = DateTime.new!(today, ~T[23:59:59], "Etc/UTC")
@@ -793,13 +696,17 @@ defmodule GymStudio.Scheduling do
     TrainingSession
     |> where([s], s.scheduled_at >= ^from_dt and s.scheduled_at <= ^to_dt)
     |> where([s], s.status in ["pending", "confirmed", "completed"])
+    |> filter_by_branch(opts[:branch_id])
     |> Repo.aggregate(:count) || 0
   end
 
   @doc """
   Counts sessions this week (all trainers).
+
+  ## Options
+  - `:branch_id` - Filter by branch ID
   """
-  def count_all_sessions_this_week do
+  def count_all_sessions_this_week(opts \\ []) do
     today = Date.utc_today()
     start_of_week = Date.beginning_of_week(today, :monday)
     end_of_next_week = Date.add(start_of_week, 7)
@@ -809,6 +716,7 @@ defmodule GymStudio.Scheduling do
     TrainingSession
     |> where([s], s.scheduled_at >= ^from_dt and s.scheduled_at < ^to_dt)
     |> where([s], s.status in ["pending", "confirmed", "completed"])
+    |> filter_by_branch(opts[:branch_id])
     |> Repo.aggregate(:count)
   end
 
@@ -821,6 +729,7 @@ defmodule GymStudio.Scheduling do
     * `:client_id` - Filter by client
     * `:from_date` - Filter from date
     * `:to_date` - Filter to date
+    * `:branch_id` - Filter by branch ID
   """
   def list_all_sessions(opts \\ []) do
     TrainingSession
@@ -828,6 +737,7 @@ defmodule GymStudio.Scheduling do
     |> filter_by_trainer(opts[:trainer_id])
     |> filter_by_client(opts[:client_id])
     |> filter_by_date_range(opts[:from_date], opts[:to_date])
+    |> filter_by_branch(opts[:branch_id])
     |> order_by([s], desc: s.scheduled_at)
     |> preload([:client, :trainer, :package])
     |> Repo.all()
@@ -912,6 +822,20 @@ defmodule GymStudio.Scheduling do
       |> where([a], a.trainer_id == ^trainer_id and a.day_of_week == ^day_of_week)
       |> Repo.one()
 
+    # Auto-fill branch_id from trainer if not provided
+    attrs =
+      if is_nil(attrs[:branch_id]) do
+        case GymStudio.Accounts.get_user(trainer_id) do
+          %GymStudio.Accounts.User{branch_id: bid} when not is_nil(bid) ->
+            Map.put(attrs, :branch_id, bid)
+
+          _ ->
+            attrs
+        end
+      else
+        attrs
+      end
+
     changeset_attrs = Map.merge(attrs, %{trainer_id: trainer_id, day_of_week: day_of_week})
 
     case existing do
@@ -946,8 +870,9 @@ defmodule GymStudio.Scheduling do
   Lists time-off entries for a trainer.
 
   ## Options
-  - `:from_date` - Filter from date (default: today)
+  - `:from_date` - Filter from date
   - `:to_date` - Filter to date
+  - `:branch_id` - Filter by branch ID
   """
   def list_trainer_time_offs(trainer_id, opts \\ []) do
     from_date = Keyword.get(opts, :from_date)
@@ -969,6 +894,20 @@ defmodule GymStudio.Scheduling do
   Creates a time-off entry.
   """
   def create_time_off(attrs) do
+    # Auto-fill branch_id from trainer if not provided
+    attrs =
+      if is_nil(attrs[:branch_id]) && attrs[:trainer_id] do
+        case GymStudio.Accounts.get_user(attrs[:trainer_id]) do
+          %GymStudio.Accounts.User{branch_id: bid} when not is_nil(bid) ->
+            Map.put(attrs, :branch_id, bid)
+
+          _ ->
+            attrs
+        end
+      else
+        attrs
+      end
+
     %TrainerTimeOff{}
     |> TrainerTimeOff.changeset(attrs)
     |> Repo.insert()
@@ -1010,7 +949,6 @@ defmodule GymStudio.Scheduling do
   def get_trainer_available_slots(trainer_id, %Date{} = date) do
     day_of_week = Date.day_of_week(date)
 
-    # 1. Get availability for this day
     availability =
       TrainerAvailability
       |> where(
@@ -1027,10 +965,8 @@ defmodule GymStudio.Scheduling do
         start_hour = start_time.hour
         end_hour = end_time.hour
 
-        # Generate all possible hours
         all_hours = Enum.to_list(start_hour..(end_hour - 1))
 
-        # 2. Remove booked hours
         start_of_day = DateTime.new!(date, ~T[00:00:00], "Etc/UTC")
         end_of_day = DateTime.new!(date, ~T[23:59:59], "Etc/UTC")
 
@@ -1044,7 +980,6 @@ defmodule GymStudio.Scheduling do
           |> Enum.map(fn dt -> dt.hour end)
           |> MapSet.new()
 
-        # 3. Remove time-off hours
         time_offs =
           TrainerTimeOff
           |> where([t], t.trainer_id == ^trainer_id and t.date == ^date)
@@ -1053,7 +988,6 @@ defmodule GymStudio.Scheduling do
         time_off_hours =
           Enum.flat_map(time_offs, fn to ->
             if is_nil(to.start_time) || is_nil(to.end_time) do
-              # All day off
               all_hours
             else
               Enum.to_list(to.start_time.hour..(to.end_time.hour - 1))
@@ -1074,12 +1008,15 @@ defmodule GymStudio.Scheduling do
   @doc """
   Returns available slots across ALL trainers for a given date.
   Returns `[%{hour: integer, label: string, trainer_id: id, trainer_name: string}]`.
+
+  ## Options
+  - `:branch_id` - Filter by branch ID
   """
-  def get_all_available_slots(%Date{} = date) do
+  def get_all_available_slots(%Date{} = date, opts \\ []) do
     day_of_week = Date.day_of_week(date)
 
     # Get all trainers with availability on this day
-    availabilities =
+    availability_query =
       TrainerAvailability
       |> where([a], a.day_of_week == ^day_of_week and a.active == true)
       |> join(:inner, [a], u in GymStudio.Accounts.User, on: a.trainer_id == u.id)
@@ -1089,81 +1026,104 @@ defmodule GymStudio.Scheduling do
         start_time: a.start_time,
         end_time: a.end_time
       })
-      |> Repo.all()
+
+    availability_query =
+      if opts[:branch_id] do
+        where(availability_query, [_a, u], u.branch_id == ^opts[:branch_id])
+      else
+        availability_query
+      end
+
+    availabilities = Repo.all(availability_query)
 
     trainer_ids = Enum.map(availabilities, & &1.trainer_id) |> Enum.uniq()
 
-    # Batch-fetch all booked hours for all trainers on this date (2 queries total)
-    start_of_day = DateTime.new!(date, ~T[00:00:00], "Etc/UTC")
-    end_of_day = DateTime.new!(date, ~T[23:59:59], "Etc/UTC")
+    if trainer_ids == [] do
+      []
+    else
+      # Batch-fetch all booked hours for all trainers on this date
+      start_of_day = DateTime.new!(date, ~T[00:00:00], "Etc/UTC")
+      end_of_day = DateTime.new!(date, ~T[23:59:59], "Etc/UTC")
 
-    booked_by_trainer =
-      TrainingSession
-      |> where([s], s.trainer_id in ^trainer_ids)
-      |> where([s], s.scheduled_at >= ^start_of_day and s.scheduled_at <= ^end_of_day)
-      |> where([s], s.status in ["pending", "confirmed"])
-      |> select([s], {s.trainer_id, s.scheduled_at})
-      |> Repo.all()
-      |> Enum.group_by(&elem(&1, 0), fn {_, dt} -> dt.hour end)
-      |> Map.new(fn {tid, hours} -> {tid, MapSet.new(hours)} end)
+      booked_by_trainer =
+        TrainingSession
+        |> where([s], s.trainer_id in ^trainer_ids)
+        |> where([s], s.scheduled_at >= ^start_of_day and s.scheduled_at <= ^end_of_day)
+        |> where([s], s.status in ["pending", "confirmed"])
+        |> select([s], {s.trainer_id, s.scheduled_at})
+        |> Repo.all()
+        |> Enum.group_by(&elem(&1, 0), fn {_, dt} -> dt.hour end)
+        |> Map.new(fn {tid, hours} -> {tid, MapSet.new(hours)} end)
 
-    time_offs_by_trainer =
-      TrainerTimeOff
-      |> where([t], t.trainer_id in ^trainer_ids and t.date == ^date)
-      |> Repo.all()
-      |> Enum.group_by(& &1.trainer_id)
+      time_offs_by_trainer =
+        TrainerTimeOff
+        |> where([t], t.trainer_id in ^trainer_ids and t.date == ^date)
+        |> Repo.all()
+        |> Enum.group_by(& &1.trainer_id)
 
-    # For each trainer, compute available slots
-    Enum.flat_map(availabilities, fn %{
-                                       trainer_id: tid,
-                                       trainer_name: tname,
-                                       start_time: st,
-                                       end_time: et
-                                     } ->
-      start_hour = st.hour
-      end_hour = et.hour
-      all_hours = Enum.to_list(start_hour..(end_hour - 1))
+      Enum.flat_map(availabilities, fn %{
+                                         trainer_id: tid,
+                                         trainer_name: tname,
+                                         start_time: st,
+                                         end_time: et
+                                       } ->
+        start_hour = st.hour
+        end_hour = et.hour
+        all_hours = Enum.to_list(start_hour..(end_hour - 1))
 
-      booked_hours = Map.get(booked_by_trainer, tid, MapSet.new())
+        booked_hours = Map.get(booked_by_trainer, tid, MapSet.new())
 
-      time_off_hours =
-        time_offs_by_trainer
-        |> Map.get(tid, [])
-        |> Enum.flat_map(fn to ->
-          if is_nil(to.start_time) || is_nil(to.end_time) do
-            all_hours
-          else
-            Enum.to_list(to.start_time.hour..(to.end_time.hour - 1))
-          end
+        time_off_hours =
+          time_offs_by_trainer
+          |> Map.get(tid, [])
+          |> Enum.flat_map(fn to ->
+            if is_nil(to.start_time) || is_nil(to.end_time) do
+              all_hours
+            else
+              Enum.to_list(to.start_time.hour..(to.end_time.hour - 1))
+            end
+          end)
+          |> MapSet.new()
+
+        blocked = MapSet.union(booked_hours, time_off_hours)
+
+        all_hours
+        |> Enum.reject(&MapSet.member?(blocked, &1))
+        |> Enum.map(fn hour ->
+          %{
+            hour: hour,
+            label: format_hour(hour),
+            value: Integer.to_string(hour),
+            trainer_id: tid,
+            trainer_name: tname || "Trainer"
+          }
         end)
-        |> MapSet.new()
-
-      blocked = MapSet.union(booked_hours, time_off_hours)
-
-      all_hours
-      |> Enum.reject(&MapSet.member?(blocked, &1))
-      |> Enum.map(fn hour ->
-        %{
-          hour: hour,
-          label: format_hour(hour),
-          value: Integer.to_string(hour),
-          trainer_id: tid,
-          trainer_name: tname || "Trainer"
-        }
       end)
-    end)
-    |> Enum.sort_by(& &1.hour)
+      |> Enum.sort_by(& &1.hour)
+    end
   end
 
   @doc """
   Lists all trainers who have availability configured.
+
+  ## Options
+  - `:branch_id` - Filter by branch ID
   """
-  def list_trainers_with_availability do
-    TrainerAvailability
-    |> join(:inner, [a], u in GymStudio.Accounts.User, on: a.trainer_id == u.id)
-    |> select([a, u], %{trainer_id: u.id, trainer_name: u.name})
-    |> distinct(true)
-    |> Repo.all()
+  def list_trainers_with_availability(opts \\ []) do
+    query =
+      TrainerAvailability
+      |> join(:inner, [a], u in GymStudio.Accounts.User, on: a.trainer_id == u.id)
+      |> select([a, u], %{trainer_id: u.id, trainer_name: u.name})
+      |> distinct(true)
+
+    query =
+      if opts[:branch_id] do
+        where(query, [_a, u], u.branch_id == ^opts[:branch_id])
+      else
+        query
+      end
+
+    Repo.all(query)
   end
 
   defp format_hour(0), do: "12:00 AM"

--- a/lib/gym_studio/scheduling.ex
+++ b/lib/gym_studio/scheduling.ex
@@ -3,6 +3,7 @@ defmodule GymStudio.Scheduling do
   The Scheduling context manages training sessions and time slots.
 
   ## Booking Flow
+
   1. Client books a session using `book_session/2` (status: pending)
   2. Admin/Trainer approves using `approve_session/3` (status: confirmed, assigns trainer)
   3. After session, trainer marks complete using `complete_session/2` (status: completed)
@@ -10,6 +11,7 @@ defmodule GymStudio.Scheduling do
   """
 
   import Ecto.Query, warn: false
+  require Logger
   alias GymStudio.Repo
 
   alias GymStudio.Scheduling.TrainingSession
@@ -40,7 +42,12 @@ defmodule GymStudio.Scheduling do
           %GymStudio.Accounts.User{branch_id: bid} when not is_nil(bid) ->
             Map.put(attrs, :branch_id, bid)
 
-          _ ->
+          %GymStudio.Accounts.User{} ->
+            Logger.warning("Auto-fill branch_id: client #{attrs[:client_id]} has nil branch_id")
+            attrs
+
+          nil ->
+            Logger.warning("Auto-fill branch_id: client #{attrs[:client_id]} not found")
             attrs
         end
       else
@@ -98,54 +105,64 @@ defmodule GymStudio.Scheduling do
 
   @doc """
   Approves a pending training session and assigns a trainer.
+
+  ## Options
+  - `:branch_id` - Verify the session belongs to this branch (returns `{:error, :wrong_branch}` if mismatch)
   """
-  def approve_session(%TrainingSession{} = session, trainer_id, approved_by_id) do
-    result =
-      session
-      |> TrainingSession.approval_changeset(%{
-        trainer_id: trainer_id,
-        approved_by_id: approved_by_id
-      })
-      |> Repo.update()
+  def approve_session(%TrainingSession{} = session, trainer_id, approved_by_id, opts \\ []) do
+    with :ok <- verify_branch(session, opts[:branch_id]) do
+      result =
+        session
+        |> TrainingSession.approval_changeset(%{
+          trainer_id: trainer_id,
+          approved_by_id: approved_by_id
+        })
+        |> Repo.update()
 
-    case result do
-      {:ok, updated_session} ->
-        GymStudio.Notifications.notify_booking_confirmed(
-          updated_session.client_id,
-          updated_session
-        )
+      case result do
+        {:ok, updated_session} ->
+          GymStudio.Notifications.notify_booking_confirmed(
+            updated_session.client_id,
+            updated_session
+          )
 
-        result
+          result
 
-      _ ->
-        result
+        _ ->
+          result
+      end
     end
   end
 
   @doc """
   Cancels a training session.
-  """
-  def cancel_session(%TrainingSession{} = session, cancelled_by_id, reason) do
-    Repo.transaction(fn ->
-      with {:ok, updated_session} <-
-             session
-             |> TrainingSession.cancellation_changeset(%{
-               cancelled_by_id: cancelled_by_id,
-               cancellation_reason: reason
-             })
-             |> Repo.update(),
-           :ok <- maybe_increment_package(updated_session) do
-        GymStudio.Notifications.notify_booking_cancelled(
-          updated_session.client_id,
-          updated_session,
-          reason
-        )
 
-        updated_session
-      else
-        {:error, changeset} -> Repo.rollback(changeset)
-      end
-    end)
+  ## Options
+  - `:branch_id` - Verify the session belongs to this branch (returns `{:error, :wrong_branch}` if mismatch)
+  """
+  def cancel_session(%TrainingSession{} = session, cancelled_by_id, reason, opts \\ []) do
+    with :ok <- verify_branch(session, opts[:branch_id]) do
+      Repo.transaction(fn ->
+        with {:ok, updated_session} <-
+               session
+               |> TrainingSession.cancellation_changeset(%{
+                 cancelled_by_id: cancelled_by_id,
+                 cancellation_reason: reason
+               })
+               |> Repo.update(),
+             :ok <- maybe_increment_package(updated_session) do
+          GymStudio.Notifications.notify_booking_cancelled(
+            updated_session.client_id,
+            updated_session,
+            reason
+          )
+
+          updated_session
+        else
+          {:error, changeset} -> Repo.rollback(changeset)
+        end
+      end)
+    end
   end
 
   defp maybe_increment_package(%TrainingSession{package_id: nil}), do: :ok
@@ -161,39 +178,49 @@ defmodule GymStudio.Scheduling do
 
   @doc """
   Marks a confirmed training session as completed.
+
+  ## Options
+  - `:branch_id` - Verify the session belongs to this branch (returns `{:error, :wrong_branch}` if mismatch)
   """
-  def complete_session(%TrainingSession{} = session, attrs \\ %{}) do
-    result =
-      session
-      |> TrainingSession.completion_changeset(attrs)
-      |> Repo.update()
+  def complete_session(%TrainingSession{} = session, attrs \\ %{}, opts \\ []) do
+    with :ok <- verify_branch(session, opts[:branch_id]) do
+      result =
+        session
+        |> TrainingSession.completion_changeset(attrs)
+        |> Repo.update()
 
-    case result do
-      {:ok, updated_session} ->
-        GymStudio.Notifications.create_notification(%{
-          user_id: updated_session.client_id,
-          title: "Session Completed",
-          message:
-            "Your session on #{Calendar.strftime(updated_session.scheduled_at, "%A, %B %d at %I:%M %p")} has been marked as completed.",
-          type: "session_completed",
-          action_url: "/client/sessions",
-          metadata: %{session_id: updated_session.id}
-        })
+      case result do
+        {:ok, updated_session} ->
+          GymStudio.Notifications.create_notification(%{
+            user_id: updated_session.client_id,
+            title: "Session Completed",
+            message:
+              "Your session on #{Calendar.strftime(updated_session.scheduled_at, "%A, %B %d at %I:%M %p")} has been marked as completed.",
+            type: "session_completed",
+            action_url: "/client/sessions",
+            metadata: %{session_id: updated_session.id}
+          })
 
-        result
+          result
 
-      _ ->
-        result
+        _ ->
+          result
+      end
     end
   end
 
   @doc """
   Marks a confirmed training session as no-show.
+
+  ## Options
+  - `:branch_id` - Verify the session belongs to this branch (returns `{:error, :wrong_branch}` if mismatch)
   """
-  def mark_no_show(%TrainingSession{} = session) do
-    session
-    |> TrainingSession.no_show_changeset()
-    |> Repo.update()
+  def mark_no_show(%TrainingSession{} = session, opts \\ []) do
+    with :ok <- verify_branch(session, opts[:branch_id]) do
+      session
+      |> TrainingSession.no_show_changeset()
+      |> Repo.update()
+    end
   end
 
   @doc """
@@ -461,45 +488,61 @@ defmodule GymStudio.Scheduling do
 
   @doc """
   Confirms a pending session (wrapper for approve when trainer is already assigned).
+
+  ## Options
+  - `:branch_id` - Verify the session belongs to this branch (returns `{:error, :wrong_branch}` if mismatch)
   """
-  def confirm_session(session_id) when is_binary(session_id) do
+  def confirm_session(session_or_id, opts \\ [])
+
+  def confirm_session(session_id, opts) when is_binary(session_id) do
     session = get_session!(session_id)
-    confirm_session(session)
+    confirm_session(session, opts)
   end
 
-  def confirm_session(%TrainingSession{} = session) do
-    if session.status == "pending" and session.trainer_id do
-      session
-      |> Ecto.Changeset.change(%{status: "confirmed"})
-      |> Repo.update()
-    else
-      {:error, :invalid_status}
+  def confirm_session(%TrainingSession{} = session, opts) do
+    with :ok <- verify_branch(session, opts[:branch_id]) do
+      if session.status == "pending" and session.trainer_id do
+        session
+        |> Ecto.Changeset.change(%{status: "confirmed"})
+        |> Repo.update()
+      else
+        {:error, :invalid_status}
+      end
     end
   end
 
   @doc """
   Cancels a session by ID with a default reason.
+
+  ## Options
+  - `:branch_id` - Verify the session belongs to this branch (returns `{:error, :wrong_branch}` if mismatch)
   """
-  def cancel_session(session_id) when is_binary(session_id) do
+  def cancel_session(session_id, opts \\ []) when is_binary(session_id) do
     session = get_session!(session_id)
-    cancel_session(session, nil, "Cancelled by user")
+    cancel_session(session, nil, "Cancelled by user", opts)
   end
 
   @doc """
   Cancels a session by ID with a specific user and reason.
+
+  ## Options
+  - `:branch_id` - Verify the session belongs to this branch (returns `{:error, :wrong_branch}` if mismatch)
   """
-  def cancel_session_by_id(session_id, cancelled_by_id, reason)
+  def cancel_session_by_id(session_id, cancelled_by_id, reason, opts \\ [])
       when is_binary(session_id) do
     session = get_session!(session_id)
-    cancel_session(session, cancelled_by_id, reason)
+    cancel_session(session, cancelled_by_id, reason, opts)
   end
 
   @doc """
   Completes a session by ID with optional attrs (e.g. trainer_notes).
+
+  ## Options
+  - `:branch_id` - Verify the session belongs to this branch (returns `{:error, :wrong_branch}` if mismatch)
   """
-  def complete_session_by_id(session_id, attrs \\ %{}) when is_binary(session_id) do
+  def complete_session_by_id(session_id, attrs \\ %{}, opts \\ []) when is_binary(session_id) do
     session = get_session!(session_id)
-    complete_session(session, attrs)
+    complete_session(session, attrs, opts)
   end
 
   @doc """
@@ -524,14 +567,18 @@ defmodule GymStudio.Scheduling do
     scheduled_at = DateTime.new!(target_date, slot.start_time, "Etc/UTC")
 
     # Get the client's branch_id
-    client = GymStudio.Accounts.get_user!(client_id)
+    case GymStudio.Accounts.get_user(client_id) do
+      %GymStudio.Accounts.User{branch_id: bid} when not is_nil(bid) ->
+        book_session(%{
+          client_id: client_id,
+          scheduled_at: scheduled_at,
+          duration_minutes: Time.diff(slot.end_time, slot.start_time, :minute),
+          branch_id: bid
+        })
 
-    book_session(%{
-      client_id: client_id,
-      scheduled_at: scheduled_at,
-      duration_minutes: Time.diff(slot.end_time, slot.start_time, :minute),
-      branch_id: client.branch_id
-    })
+      _ ->
+        {:error, :user_not_found}
+    end
   end
 
   @doc """
@@ -572,6 +619,18 @@ defmodule GymStudio.Scheduling do
 
   defp filter_by_branch(query, branch_id) do
     where(query, [s], s.branch_id == ^branch_id)
+  end
+
+  defp filter_time_off_by_branch(query, nil), do: query
+
+  defp filter_time_off_by_branch(query, branch_id) do
+    where(query, [t], t.branch_id == ^branch_id)
+  end
+
+  defp verify_branch(_session, nil), do: :ok
+
+  defp verify_branch(%TrainingSession{branch_id: session_branch_id}, branch_id) do
+    if session_branch_id == branch_id, do: :ok, else: {:error, :wrong_branch}
   end
 
   defp filter_by_date_range(query, nil, nil), do: query
@@ -630,19 +689,26 @@ defmodule GymStudio.Scheduling do
   def sessions_per_week(num_weeks \\ 4, opts \\ []) do
     today = Date.utc_today()
     start_of_this_week = Date.beginning_of_week(today, :monday)
+    earliest = Date.add(start_of_this_week, -7 * (num_weeks - 1))
+
+    from_dt = DateTime.new!(earliest, ~T[00:00:00], "Etc/UTC")
+    to_dt = DateTime.new!(Date.add(start_of_this_week, 6), ~T[23:59:59], "Etc/UTC")
+
+    # Single query: compute the Monday of each session's week, then GROUP BY that
+    counts_by_week =
+      TrainingSession
+      |> where([s], s.scheduled_at >= ^from_dt and s.scheduled_at <= ^to_dt)
+      |> filter_by_branch(opts[:branch_id])
+      |> group_by([s], fragment("date_trunc('week', ?)::date", s.scheduled_at))
+      |> select([s], {fragment("date_trunc('week', ?)::date", s.scheduled_at), count(s.id)})
+      |> Repo.all()
+      |> Map.new()
 
     Enum.map(0..(num_weeks - 1), fn weeks_ago ->
       week_start = Date.add(start_of_this_week, -7 * weeks_ago)
       week_end = Date.add(week_start, 6)
-      from_dt = DateTime.new!(week_start, ~T[00:00:00], "Etc/UTC")
-      to_dt = DateTime.new!(week_end, ~T[23:59:59], "Etc/UTC")
-
-      count =
-        TrainingSession
-        |> where([s], s.scheduled_at >= ^from_dt and s.scheduled_at <= ^to_dt)
-        |> filter_by_branch(opts[:branch_id])
-        |> Repo.aggregate(:count) || 0
-
+      # PostgreSQL date_trunc('week') returns Monday
+      count = Map.get(counts_by_week, week_start, 0)
       {week_start, week_end, count}
     end)
     |> Enum.reverse()
@@ -759,29 +825,44 @@ defmodule GymStudio.Scheduling do
 
   @doc """
   Admin override: directly set a session's status.
+
+  ## Options
+  - `:branch_id` - Verify the session belongs to this branch (returns `{:error, :wrong_branch}` if mismatch)
   """
-  def admin_update_session(%TrainingSession{} = session, attrs) do
-    session
-    |> Ecto.Changeset.cast(attrs, [:status, :trainer_id, :notes])
-    |> Repo.update()
+  def admin_update_session(%TrainingSession{} = session, attrs, opts \\ []) do
+    with :ok <- verify_branch(session, opts[:branch_id]) do
+      session
+      |> Ecto.Changeset.cast(attrs, [:status, :trainer_id, :notes])
+      |> Repo.update()
+    end
   end
 
   @doc """
   Updates a session's status directly (admin override).
+
+  ## Options
+  - `:branch_id` - Verify the session belongs to this branch (returns `{:error, :wrong_branch}` if mismatch)
   """
-  def update_session_status(%TrainingSession{} = session, new_status) do
-    session
-    |> Ecto.Changeset.change(%{status: new_status})
-    |> Repo.update()
+  def update_session_status(%TrainingSession{} = session, new_status, opts \\ []) do
+    with :ok <- verify_branch(session, opts[:branch_id]) do
+      session
+      |> Ecto.Changeset.change(%{status: new_status})
+      |> Repo.update()
+    end
   end
 
   @doc """
   Assigns a trainer to a session.
+
+  ## Options
+  - `:branch_id` - Verify the session belongs to this branch (returns `{:error, :wrong_branch}` if mismatch)
   """
-  def assign_trainer(%TrainingSession{} = session, trainer_id) do
-    session
-    |> Ecto.Changeset.change(%{trainer_id: trainer_id})
-    |> Repo.update()
+  def assign_trainer(%TrainingSession{} = session, trainer_id, opts \\ []) do
+    with :ok <- verify_branch(session, opts[:branch_id]) do
+      session
+      |> Ecto.Changeset.change(%{trainer_id: trainer_id})
+      |> Repo.update()
+    end
   end
 
   # =============================================================================
@@ -829,7 +910,18 @@ defmodule GymStudio.Scheduling do
           %GymStudio.Accounts.User{branch_id: bid} when not is_nil(bid) ->
             Map.put(attrs, :branch_id, bid)
 
-          _ ->
+          %GymStudio.Accounts.User{} ->
+            Logger.warning(
+              "Auto-fill branch_id: trainer #{trainer_id} has nil branch_id in set_trainer_availability"
+            )
+
+            attrs
+
+          nil ->
+            Logger.warning(
+              "Auto-fill branch_id: trainer #{trainer_id} not found in set_trainer_availability"
+            )
+
             attrs
         end
       else
@@ -886,6 +978,7 @@ defmodule GymStudio.Scheduling do
     |> then(fn q ->
       if to_date, do: where(q, [t], t.date <= ^to_date), else: q
     end)
+    |> filter_time_off_by_branch(opts[:branch_id])
     |> order_by([t], asc: t.date)
     |> Repo.all()
   end
@@ -901,7 +994,18 @@ defmodule GymStudio.Scheduling do
           %GymStudio.Accounts.User{branch_id: bid} when not is_nil(bid) ->
             Map.put(attrs, :branch_id, bid)
 
-          _ ->
+          %GymStudio.Accounts.User{} ->
+            Logger.warning(
+              "Auto-fill branch_id: trainer #{attrs[:trainer_id]} has nil branch_id in create_time_off"
+            )
+
+            attrs
+
+          nil ->
+            Logger.warning(
+              "Auto-fill branch_id: trainer #{attrs[:trainer_id]} not found in create_time_off"
+            )
+
             attrs
         end
       else

--- a/lib/gym_studio/scheduling/trainer_availability.ex
+++ b/lib/gym_studio/scheduling/trainer_availability.ex
@@ -12,6 +12,7 @@ defmodule GymStudio.Scheduling.TrainerAvailability do
 
   schema "trainer_availabilities" do
     belongs_to :trainer, User
+    belongs_to :branch, GymStudio.Branches.Branch, type: :integer
     field :day_of_week, :integer
     field :start_time, :time
     field :end_time, :time
@@ -34,11 +35,12 @@ defmodule GymStudio.Scheduling.TrainerAvailability do
 
   def changeset(availability, attrs) do
     availability
-    |> cast(attrs, [:trainer_id, :day_of_week, :start_time, :end_time, :active])
-    |> validate_required([:trainer_id, :day_of_week, :start_time, :end_time])
+    |> cast(attrs, [:trainer_id, :day_of_week, :start_time, :end_time, :active, :branch_id])
+    |> validate_required([:trainer_id, :day_of_week, :start_time, :end_time, :branch_id])
     |> validate_number(:day_of_week, greater_than_or_equal_to: 1, less_than_or_equal_to: 7)
     |> validate_time_range()
     |> unique_constraint([:trainer_id, :day_of_week])
+    |> foreign_key_constraint(:branch_id)
   end
 
   defp validate_time_range(changeset) do

--- a/lib/gym_studio/scheduling/trainer_time_off.ex
+++ b/lib/gym_studio/scheduling/trainer_time_off.ex
@@ -12,6 +12,7 @@ defmodule GymStudio.Scheduling.TrainerTimeOff do
 
   schema "trainer_time_offs" do
     belongs_to :trainer, User
+    belongs_to :branch, GymStudio.Branches.Branch, type: :integer
     field :date, :date
     field :start_time, :time
     field :end_time, :time
@@ -22,9 +23,10 @@ defmodule GymStudio.Scheduling.TrainerTimeOff do
 
   def changeset(time_off, attrs) do
     time_off
-    |> cast(attrs, [:trainer_id, :date, :start_time, :end_time, :reason])
-    |> validate_required([:trainer_id, :date])
+    |> cast(attrs, [:trainer_id, :date, :start_time, :end_time, :reason, :branch_id])
+    |> validate_required([:trainer_id, :date, :branch_id])
     |> validate_time_range()
+    |> foreign_key_constraint(:branch_id)
   end
 
   defp validate_time_range(changeset) do

--- a/lib/gym_studio/scheduling/training_session.ex
+++ b/lib/gym_studio/scheduling/training_session.ex
@@ -30,6 +30,7 @@ defmodule GymStudio.Scheduling.TrainingSession do
     belongs_to :package, GymStudio.Packages.SessionPackage
     belongs_to :approved_by, User
     belongs_to :cancelled_by, User
+    belongs_to :branch, GymStudio.Branches.Branch, type: :integer
 
     field :scheduled_at, :utc_datetime
     field :duration_minutes, :integer, default: 60
@@ -70,14 +71,16 @@ defmodule GymStudio.Scheduling.TrainingSession do
       :package_id,
       :scheduled_at,
       :duration_minutes,
-      :notes
+      :notes,
+      :branch_id
     ])
-    |> validate_required([:client_id, :scheduled_at, :duration_minutes])
+    |> validate_required([:client_id, :scheduled_at, :duration_minutes, :branch_id])
     |> validate_number(:duration_minutes, greater_than: 0)
     |> validate_scheduled_at_in_future()
     |> foreign_key_constraint(:client_id)
     |> foreign_key_constraint(:trainer_id)
     |> foreign_key_constraint(:package_id)
+    |> foreign_key_constraint(:branch_id)
     |> unique_constraint(:trainer_id,
       name: :training_sessions_trainer_scheduled_at_active_index,
       message: "slot already taken"

--- a/lib/gym_studio_web/live/admin/analytics_live.ex
+++ b/lib/gym_studio_web/live/admin/analytics_live.ex
@@ -5,10 +5,11 @@ defmodule GymStudioWeb.Admin.AnalyticsLive do
 
   @impl true
   def mount(_params, _session, socket) do
-    status_counts = Scheduling.count_sessions_by_status()
-    weekly_sessions = Scheduling.sessions_per_week(4)
-    popular_slots = Scheduling.popular_time_slots()
-    trainer_counts = Scheduling.trainer_session_counts()
+    branch_id = socket.assigns.current_scope.user.branch_id
+    status_counts = Scheduling.count_sessions_by_status(branch_id: branch_id)
+    weekly_sessions = Scheduling.sessions_per_week(4, branch_id: branch_id)
+    popular_slots = Scheduling.popular_time_slots(branch_id: branch_id)
+    trainer_counts = Scheduling.trainer_session_counts(branch_id: branch_id)
 
     total_sessions = status_counts |> Map.values() |> Enum.sum()
 

--- a/lib/gym_studio_web/live/admin/availability_live.ex
+++ b/lib/gym_studio_web/live/admin/availability_live.ex
@@ -15,7 +15,8 @@ defmodule GymStudioWeb.Admin.AvailabilityLive do
 
   @impl true
   def mount(_params, _session, socket) do
-    trainers = Scheduling.list_trainers_with_availability()
+    branch_id = socket.assigns.current_scope.user.branch_id
+    trainers = Scheduling.list_trainers_with_availability(branch_id: branch_id)
 
     # Build availability map: %{trainer_id => %{day => availability}}
     trainer_ids = Enum.map(trainers, & &1.trainer_id)
@@ -62,6 +63,7 @@ defmodule GymStudioWeb.Admin.AvailabilityLive do
       attrs = %{
         start_time: parse_time(params["start_time"]),
         end_time: parse_time(params["end_time"]),
+        branch_id: socket.assigns.current_scope.user.branch_id,
         active: true
       }
 

--- a/lib/gym_studio_web/live/admin/calendar_live.ex
+++ b/lib/gym_studio_web/live/admin/calendar_live.ex
@@ -19,7 +19,8 @@ defmodule GymStudioWeb.Admin.CalendarLive do
   @impl true
   def mount(_params, _session, socket) do
     today = Date.utc_today()
-    trainers = Accounts.list_trainers(status: "approved")
+    branch_id = socket.assigns.current_scope.user.branch_id
+    trainers = Accounts.list_trainers(status: "approved", branch_id: branch_id)
 
     # Build trainer_id -> color mapping
     color_map =
@@ -38,6 +39,7 @@ defmodule GymStudioWeb.Admin.CalendarLive do
       |> assign(current_week_start: Date.beginning_of_week(today, :monday))
       |> assign(selected_session: nil)
       |> assign(available_trainers: [])
+      |> assign(branch_id: branch_id)
       |> load_week_data()
 
     {:ok, socket}
@@ -48,7 +50,7 @@ defmodule GymStudioWeb.Admin.CalendarLive do
     week_end = Date.add(week_start, 6)
     filter = socket.assigns.filter_trainer_id
 
-    opts = [from_date: week_start, to_date: week_end]
+    opts = [from_date: week_start, to_date: week_end, branch_id: socket.assigns.branch_id]
     opts = if filter, do: Keyword.put(opts, :trainer_id, filter), else: opts
 
     sessions = Scheduling.list_all_sessions(opts)
@@ -129,7 +131,7 @@ defmodule GymStudioWeb.Admin.CalendarLive do
       session ->
         available_trainers =
           if is_nil(session.trainer_id) do
-            Accounts.list_approved_trainers()
+            Accounts.list_approved_trainers(branch_id: socket.assigns.branch_id)
           else
             []
           end

--- a/lib/gym_studio_web/live/admin/calendar_live.ex
+++ b/lib/gym_studio_web/live/admin/calendar_live.ex
@@ -154,7 +154,7 @@ defmodule GymStudioWeb.Admin.CalendarLive do
         do: Map.put(attrs, :status, "confirmed"),
         else: attrs
 
-    case Scheduling.admin_update_session(session, attrs) do
+    case Scheduling.admin_update_session(session, attrs, branch_id: socket.assigns.branch_id) do
       {:ok, _} ->
         socket =
           socket

--- a/lib/gym_studio_web/live/admin/clients_live.ex
+++ b/lib/gym_studio_web/live/admin/clients_live.ex
@@ -4,7 +4,7 @@ defmodule GymStudioWeb.Admin.ClientsLive do
 
   @impl true
   def mount(_params, _session, socket) do
-    clients = Accounts.list_clients()
+    clients = Accounts.list_clients(branch_id: socket.assigns.current_scope.user.branch_id)
     {:ok, assign(socket, page_title: "Manage Clients", clients: clients)}
   end
 

--- a/lib/gym_studio_web/live/admin/dashboard_live.ex
+++ b/lib/gym_studio_web/live/admin/dashboard_live.ex
@@ -8,15 +8,22 @@ defmodule GymStudioWeb.Admin.DashboardLive do
 
   @impl true
   def mount(_params, _session, socket) do
-    user_counts = Accounts.count_users_by_role()
-    pending_trainers = length(Accounts.list_trainers(status: "pending"))
-    pending_sessions = length(Scheduling.list_pending_sessions())
+    branch_id = socket.assigns.current_scope.user.branch_id
+    user_counts = Accounts.count_users_by_role(branch_id: branch_id)
+    pending_trainers = length(Accounts.list_trainers(status: "pending", branch_id: branch_id))
+    pending_sessions = length(Scheduling.list_pending_sessions(branch_id: branch_id))
 
     active_packages =
-      length(Packages.list_all_packages(active: true, has_available_sessions: true))
+      length(
+        Packages.list_all_packages(
+          active: true,
+          has_available_sessions: true,
+          branch_id: branch_id
+        )
+      )
 
-    sessions_today = Scheduling.count_sessions_today()
-    sessions_this_week = Scheduling.count_all_sessions_this_week()
+    sessions_today = Scheduling.count_sessions_today(branch_id: branch_id)
+    sessions_this_week = Scheduling.count_all_sessions_this_week(branch_id: branch_id)
 
     {:ok,
      assign(socket,

--- a/lib/gym_studio_web/live/admin/packages_live.ex
+++ b/lib/gym_studio_web/live/admin/packages_live.ex
@@ -4,8 +4,9 @@ defmodule GymStudioWeb.Admin.PackagesLive do
 
   @impl true
   def mount(_params, _session, socket) do
-    packages = Packages.list_all_packages()
-    clients = Accounts.list_users(role: :client)
+    branch_id = socket.assigns.current_scope.user.branch_id
+    packages = Packages.list_all_packages(branch_id: branch_id)
+    clients = Accounts.list_users(role: :client, branch_id: branch_id)
     package_types = Packages.package_types()
 
     {:ok,
@@ -36,6 +37,7 @@ defmodule GymStudioWeb.Admin.PackagesLive do
       client_id: params["client_id"],
       package_type: params["package_type"],
       assigned_by_id: socket.assigns.current_scope.user.id,
+      branch_id: socket.assigns.current_scope.user.branch_id,
       expires_at: parse_expires_at(params["expires_at"])
     }
 
@@ -54,7 +56,12 @@ defmodule GymStudioWeb.Admin.PackagesLive do
   def handle_event("deactivate", %{"id" => id}, socket) do
     package = Packages.get_package!(id)
     {:ok, _} = Packages.deactivate_package(package)
-    {:noreply, assign(socket, packages: Packages.list_all_packages())}
+
+    {:noreply,
+     assign(socket,
+       packages:
+         Packages.list_all_packages(branch_id: socket.assigns.current_scope.user.branch_id)
+     )}
   end
 
   defp parse_expires_at(nil), do: nil

--- a/lib/gym_studio_web/live/admin/sessions_live.ex
+++ b/lib/gym_studio_web/live/admin/sessions_live.ex
@@ -4,16 +4,18 @@ defmodule GymStudioWeb.Admin.SessionsLive do
 
   @impl true
   def mount(_params, _session, socket) do
-    trainers = Accounts.list_approved_trainers()
+    branch_id = socket.assigns.current_scope.user.branch_id
+    trainers = Accounts.list_approved_trainers(branch_id: branch_id)
 
     {:ok,
      assign(socket,
        page_title: "Manage Sessions",
-       sessions: Scheduling.list_all_sessions(),
+       sessions: Scheduling.list_all_sessions(branch_id: branch_id),
        trainers: trainers,
        status_filter: "",
        trainer_filter: "",
-       editing_session_id: nil
+       editing_session_id: nil,
+       branch_id: branch_id
      )}
   end
 
@@ -26,6 +28,7 @@ defmodule GymStudioWeb.Admin.SessionsLive do
       []
       |> then(fn o -> if status != "", do: [{:status, status} | o], else: o end)
       |> then(fn o -> if trainer != "", do: [{:trainer_id, trainer} | o], else: o end)
+      |> Keyword.put(:branch_id, socket.assigns.branch_id)
 
     sessions = Scheduling.list_all_sessions(opts)
 
@@ -64,6 +67,7 @@ defmodule GymStudioWeb.Admin.SessionsLive do
           do: [{:trainer_id, socket.assigns.trainer_filter} | o],
           else: o
       end)
+      |> Keyword.put(:branch_id, socket.assigns.branch_id)
 
     assign(socket, sessions: Scheduling.list_all_sessions(opts))
   end

--- a/lib/gym_studio_web/live/admin/sessions_live.ex
+++ b/lib/gym_studio_web/live/admin/sessions_live.ex
@@ -37,7 +37,12 @@ defmodule GymStudioWeb.Admin.SessionsLive do
 
   def handle_event("set_status", %{"id" => id, "status" => new_status}, socket) do
     session = Scheduling.get_session!(id)
-    {:ok, _} = Scheduling.admin_update_session(session, %{status: new_status})
+
+    {:ok, _} =
+      Scheduling.admin_update_session(session, %{status: new_status},
+        branch_id: socket.assigns.branch_id
+      )
+
     {:noreply, reload_sessions(socket)}
   end
 
@@ -50,7 +55,9 @@ defmodule GymStudioWeb.Admin.SessionsLive do
         do: Map.put(attrs, :status, "confirmed"),
         else: attrs
 
-    {:ok, _} = Scheduling.admin_update_session(session, attrs)
+    {:ok, _} =
+      Scheduling.admin_update_session(session, attrs, branch_id: socket.assigns.branch_id)
+
     {:noreply, reload_sessions(socket)}
   end
 

--- a/lib/gym_studio_web/live/admin/trainers_live.ex
+++ b/lib/gym_studio_web/live/admin/trainers_live.ex
@@ -4,7 +4,7 @@ defmodule GymStudioWeb.Admin.TrainersLive do
 
   @impl true
   def mount(_params, _session, socket) do
-    trainers = Accounts.list_trainers()
+    trainers = Accounts.list_trainers(branch_id: socket.assigns.current_scope.user.branch_id)
     {:ok, assign(socket, page_title: "Manage Trainers", trainers: trainers)}
   end
 

--- a/lib/gym_studio_web/live/admin/users_live.ex
+++ b/lib/gym_studio_web/live/admin/users_live.ex
@@ -5,14 +5,17 @@ defmodule GymStudioWeb.Admin.UsersLive do
 
   @impl true
   def mount(_params, _session, socket) do
+    branch_id = socket.assigns.current_scope.user.branch_id
+
     {:ok,
      assign(socket,
        page_title: "Manage Users",
-       users: Accounts.list_users(),
+       users: Accounts.list_users(branch_id: branch_id),
        search: "",
        role_filter: "",
        confirm_action: nil,
-       confirm_user_id: nil
+       confirm_user_id: nil,
+       branch_id: branch_id
      )}
   end
 
@@ -28,7 +31,8 @@ defmodule GymStudioWeb.Admin.UsersLive do
 
   @impl true
   def handle_event("search", %{"search" => search, "role" => role}, socket) do
-    users = filter_users(search, role)
+    branch_id = socket.assigns.branch_id
+    users = filter_users(search, role, branch_id)
     {:noreply, assign(socket, users: users, search: search, role_filter: role)}
   end
 
@@ -41,7 +45,9 @@ defmodule GymStudioWeb.Admin.UsersLive do
       {:ok, _} = Accounts.activate_user(user)
     end
 
-    users = filter_users(socket.assigns.search, socket.assigns.role_filter)
+    users =
+      filter_users(socket.assigns.search, socket.assigns.role_filter, socket.assigns.branch_id)
+
     {:noreply, assign(socket, users: users)}
   end
 
@@ -58,7 +64,9 @@ defmodule GymStudioWeb.Admin.UsersLive do
     user = Accounts.get_user!(socket.assigns.confirm_user_id)
     {:ok, _} = Accounts.change_user_role(user, socket.assigns.confirm_role)
 
-    users = filter_users(socket.assigns.search, socket.assigns.role_filter)
+    users =
+      filter_users(socket.assigns.search, socket.assigns.role_filter, socket.assigns.branch_id)
+
     {:noreply, assign(socket, users: users, confirm_action: nil, confirm_user_id: nil)}
   end
 
@@ -66,12 +74,16 @@ defmodule GymStudioWeb.Admin.UsersLive do
     {:noreply, assign(socket, confirm_action: nil, confirm_user_id: nil)}
   end
 
-  defp filter_users("", ""), do: Accounts.list_users()
-  defp filter_users("", role), do: Accounts.list_users(role: String.to_existing_atom(role))
-  defp filter_users(search, ""), do: Accounts.search_users(search)
+  defp filter_users("", "", branch_id), do: Accounts.list_users(branch_id: branch_id)
 
-  defp filter_users(search, role),
-    do: Accounts.search_users(search, role: String.to_existing_atom(role))
+  defp filter_users("", role, branch_id),
+    do: Accounts.list_users(role: String.to_existing_atom(role), branch_id: branch_id)
+
+  defp filter_users(search, "", branch_id),
+    do: Accounts.search_users(search, branch_id: branch_id)
+
+  defp filter_users(search, role, branch_id),
+    do: Accounts.search_users(search, role: String.to_existing_atom(role), branch_id: branch_id)
 
   defp display_name(%{name: name}) when is_binary(name) and name != "", do: name
   defp display_name(%{email: email}) when is_binary(email), do: email

--- a/lib/gym_studio_web/live/client/book_session_live.ex
+++ b/lib/gym_studio_web/live/client/book_session_live.ex
@@ -46,7 +46,9 @@ defmodule GymStudioWeb.Client.BookSessionLive do
       |> assign(active_package: active_package)
       |> assign(available_dates: available_dates)
       |> assign(selected_date: selected_date)
-      |> assign(available_slots: load_slots(selected_date))
+      |> assign(
+        available_slots: load_slots(selected_date, socket.assigns.current_scope.user.branch_id)
+      )
       |> assign(selected_slot: nil)
       |> assign(selected_trainer_id: nil)
       |> assign(notes: "")
@@ -82,7 +84,9 @@ defmodule GymStudioWeb.Client.BookSessionLive do
         socket =
           socket
           |> assign(selected_date: date)
-          |> assign(available_slots: load_slots(date))
+          |> assign(
+            available_slots: load_slots(date, socket.assigns.current_scope.user.branch_id)
+          )
           |> assign(selected_slot: nil)
           |> assign(selected_trainer_id: nil)
           |> assign(step: 2)
@@ -147,6 +151,7 @@ defmodule GymStudioWeb.Client.BookSessionLive do
           trainer_id: selected_trainer_id,
           scheduled_at: scheduled_at,
           duration_minutes: 60,
+          branch_id: user.branch_id,
           notes: if(socket.assigns.notes != "", do: socket.assigns.notes, else: nil)
         }
 
@@ -167,7 +172,11 @@ defmodule GymStudioWeb.Client.BookSessionLive do
               socket
               |> put_flash(:error, "This slot was just taken. Please choose another time.")
               |> assign(
-                available_slots: load_slots(socket.assigns.selected_date),
+                available_slots:
+                  load_slots(
+                    socket.assigns.selected_date,
+                    socket.assigns.current_scope.user.branch_id
+                  ),
                 selected_slot: nil,
                 selected_trainer_id: nil,
                 step: 2
@@ -191,10 +200,10 @@ defmodule GymStudioWeb.Client.BookSessionLive do
     {:noreply, assign(socket, step: 2)}
   end
 
-  defp load_slots(nil), do: []
+  defp load_slots(nil, _branch_id), do: []
 
-  defp load_slots(date) do
-    Scheduling.get_all_available_slots(date)
+  defp load_slots(date, branch_id) do
+    Scheduling.get_all_available_slots(date, branch_id: branch_id)
   end
 
   defp generate_available_dates do

--- a/lib/gym_studio_web/live/client/dashboard_live.ex
+++ b/lib/gym_studio_web/live/client/dashboard_live.ex
@@ -27,8 +27,10 @@ defmodule GymStudioWeb.Client.DashboardLive do
   end
 
   defp assign_dashboard_data(socket, client) do
+    branch_id = socket.assigns.current_scope.user.branch_id
+
     active_package =
-      case Packages.get_active_package_for_client(client.user_id) do
+      case Packages.get_active_package_for_client(client.user_id, branch_id: branch_id) do
         {:ok, package} -> package
         {:error, :no_active_package} -> nil
       end

--- a/lib/gym_studio_web/live/client/packages_live.ex
+++ b/lib/gym_studio_web/live/client/packages_live.ex
@@ -7,7 +7,7 @@ defmodule GymStudioWeb.Client.PackagesLive do
     user = socket.assigns.current_scope.user
     client = Accounts.get_client_by_user_id(user.id)
 
-    packages = Packages.list_packages_for_client(user.id)
+    packages = Packages.list_packages_for_client(user.id, branch_id: user.branch_id)
 
     socket =
       socket

--- a/lib/gym_studio_web/live/client/sessions_live.ex
+++ b/lib/gym_studio_web/live/client/sessions_live.ex
@@ -38,7 +38,9 @@ defmodule GymStudioWeb.Client.SessionsLive do
 
   @impl true
   def handle_event("cancel_session", %{"session_id" => session_id}, socket) do
-    case Scheduling.cancel_session(session_id) do
+    user = socket.assigns.user
+
+    case Scheduling.cancel_session(session_id, branch_id: user.branch_id) do
       {:ok, _session} ->
         user = socket.assigns.user
         sessions = Scheduling.list_sessions_for_client(user.id, branch_id: user.branch_id)

--- a/lib/gym_studio_web/live/client/sessions_live.ex
+++ b/lib/gym_studio_web/live/client/sessions_live.ex
@@ -7,7 +7,7 @@ defmodule GymStudioWeb.Client.SessionsLive do
     user = socket.assigns.current_scope.user
     client = Accounts.get_client_by_user_id(user.id)
 
-    sessions = Scheduling.list_sessions_for_client(user.id)
+    sessions = Scheduling.list_sessions_for_client(user.id, branch_id: user.branch_id)
 
     socket =
       socket
@@ -26,8 +26,11 @@ defmodule GymStudioWeb.Client.SessionsLive do
 
     sessions =
       case status do
-        "all" -> Scheduling.list_sessions_for_client(user.id)
-        _ -> Scheduling.list_sessions_for_client(user.id, status: status)
+        "all" ->
+          Scheduling.list_sessions_for_client(user.id, branch_id: user.branch_id)
+
+        _ ->
+          Scheduling.list_sessions_for_client(user.id, status: status, branch_id: user.branch_id)
       end
 
     {:noreply, assign(socket, sessions: sessions, filter: status)}
@@ -38,7 +41,7 @@ defmodule GymStudioWeb.Client.SessionsLive do
     case Scheduling.cancel_session(session_id) do
       {:ok, _session} ->
         user = socket.assigns.user
-        sessions = Scheduling.list_sessions_for_client(user.id)
+        sessions = Scheduling.list_sessions_for_client(user.id, branch_id: user.branch_id)
 
         socket =
           socket

--- a/lib/gym_studio_web/live/registration_live.ex
+++ b/lib/gym_studio_web/live/registration_live.ex
@@ -390,6 +390,15 @@ defmodule GymStudioWeb.RegistrationLive do
       user_params
       |> Map.put("phone_number", socket.assigns.phone_number)
 
+    # Default to first active branch if not specified
+    user_params =
+      if Map.has_key?(user_params, "branch_id") do
+        user_params
+      else
+        default_branch = GymStudio.Branches.get_default_branch()
+        Map.put(user_params, "branch_id", default_branch && default_branch.id)
+      end
+
     case Accounts.register_user(user_params) do
       {:ok, user} ->
         # Mark the user as confirmed since phone was verified

--- a/lib/gym_studio_web/live/registration_live.ex
+++ b/lib/gym_studio_web/live/registration_live.ex
@@ -9,6 +9,8 @@ defmodule GymStudioWeb.RegistrationLive do
   """
   use GymStudioWeb, :live_view
 
+  require Logger
+
   alias GymStudio.Accounts
   alias GymStudio.Accounts.User
   alias GymStudio.PhoneUtils
@@ -395,8 +397,14 @@ defmodule GymStudioWeb.RegistrationLive do
       if Map.has_key?(user_params, "branch_id") do
         user_params
       else
-        default_branch = GymStudio.Branches.get_default_branch()
-        Map.put(user_params, "branch_id", default_branch && default_branch.id)
+        case GymStudio.Branches.get_default_branch() do
+          nil ->
+            Logger.warning("No active branch found during registration; branch_id will be nil")
+            user_params
+
+          default_branch ->
+            Map.put(user_params, "branch_id", default_branch.id)
+        end
       end
 
     case Accounts.register_user(user_params) do

--- a/lib/gym_studio_web/live/trainer/client_list_live.ex
+++ b/lib/gym_studio_web/live/trainer/client_list_live.ex
@@ -10,7 +10,7 @@ defmodule GymStudioWeb.Trainer.ClientListLive do
   @impl true
   def mount(_params, _session, socket) do
     user = socket.assigns.current_scope.user
-    clients = Scheduling.list_trainer_clients(user.id)
+    clients = Scheduling.list_trainer_clients(user.id, branch_id: user.branch_id)
 
     socket =
       socket
@@ -24,7 +24,7 @@ defmodule GymStudioWeb.Trainer.ClientListLive do
   @impl true
   def handle_event("search", %{"search" => search}, socket) do
     user = socket.assigns.current_scope.user
-    clients = Scheduling.list_trainer_clients(user.id, search: search)
+    clients = Scheduling.list_trainer_clients(user.id, search: search, branch_id: user.branch_id)
     {:noreply, assign(socket, clients: clients, search: search)}
   end
 

--- a/lib/gym_studio_web/live/trainer/dashboard_live.ex
+++ b/lib/gym_studio_web/live/trainer/dashboard_live.ex
@@ -28,9 +28,14 @@ defmodule GymStudioWeb.Trainer.DashboardLive do
 
   defp assign_dashboard_data(socket, trainer) do
     today = Date.utc_today()
+    branch_id = socket.assigns.current_scope.user.branch_id
 
     todays_sessions =
-      Scheduling.list_sessions_for_trainer(trainer.user_id, from_date: today, to_date: today)
+      Scheduling.list_sessions_for_trainer(trainer.user_id,
+        from_date: today,
+        to_date: today,
+        branch_id: branch_id
+      )
 
     pending_sessions = Scheduling.list_pending_sessions_for_trainer(trainer.user_id)
 
@@ -41,7 +46,8 @@ defmodule GymStudioWeb.Trainer.DashboardLive do
     upcoming_sessions =
       Scheduling.list_sessions_for_trainer(trainer.user_id,
         from_date: tomorrow,
-        to_date: week_end
+        to_date: week_end,
+        branch_id: branch_id
       )
       |> Enum.filter(&(&1.status in ["pending", "confirmed"]))
       |> Enum.sort_by(& &1.scheduled_at, DateTime)

--- a/lib/gym_studio_web/live/trainer/dashboard_live.ex
+++ b/lib/gym_studio_web/live/trainer/dashboard_live.ex
@@ -67,7 +67,9 @@ defmodule GymStudioWeb.Trainer.DashboardLive do
 
   @impl true
   def handle_event("confirm_session", %{"session_id" => session_id}, socket) do
-    case Scheduling.confirm_session(session_id) do
+    branch_id = socket.assigns.current_scope.user.branch_id
+
+    case Scheduling.confirm_session(session_id, branch_id: branch_id) do
       {:ok, _session} ->
         socket = assign_dashboard_data(socket, socket.assigns.trainer)
         {:noreply, put_flash(socket, :info, "Session confirmed.")}
@@ -98,7 +100,9 @@ defmodule GymStudioWeb.Trainer.DashboardLive do
 
     reason = if reason == "", do: "Cancelled by trainer", else: reason
 
-    case Scheduling.cancel_session_by_id(session_id, user.id, reason) do
+    case Scheduling.cancel_session_by_id(session_id, user.id, reason,
+           branch_id: socket.assigns.current_scope.user.branch_id
+         ) do
       {:ok, _session} ->
         socket =
           socket
@@ -133,7 +137,9 @@ defmodule GymStudioWeb.Trainer.DashboardLive do
 
     attrs = if notes != "", do: %{trainer_notes: notes}, else: %{}
 
-    case Scheduling.complete_session_by_id(session_id, attrs) do
+    case Scheduling.complete_session_by_id(session_id, attrs,
+           branch_id: socket.assigns.current_scope.user.branch_id
+         ) do
       {:ok, _session} ->
         socket =
           socket

--- a/lib/gym_studio_web/live/trainer/schedule_live.ex
+++ b/lib/gym_studio_web/live/trainer/schedule_live.ex
@@ -33,13 +33,18 @@ defmodule GymStudioWeb.Trainer.ScheduleLive do
     assign(socket, week_sessions: %{}, availability_map: %{})
   end
 
-  defp load_week_data(%{assigns: %{trainer: trainer, current_week_start: week_start}} = socket) do
+  defp load_week_data(
+         %{assigns: %{trainer: trainer, current_week_start: week_start, current_scope: scope}} =
+           socket
+       ) do
     week_end = Date.add(week_start, 6)
+    branch_id = scope.user.branch_id
 
     sessions =
       Scheduling.list_sessions_for_trainer(trainer.user_id,
         from_date: week_start,
-        to_date: week_end
+        to_date: week_end,
+        branch_id: branch_id
       )
 
     week_sessions =

--- a/lib/gym_studio_web/live/trainer/sessions_live.ex
+++ b/lib/gym_studio_web/live/trainer/sessions_live.ex
@@ -21,11 +21,21 @@ defmodule GymStudioWeb.Trainer.SessionsLive do
 
   defp load_sessions(%{assigns: %{trainer: nil}} = socket), do: assign(socket, sessions: [])
 
-  defp load_sessions(%{assigns: %{trainer: trainer, filter: filter}} = socket) do
+  defp load_sessions(
+         %{assigns: %{trainer: trainer, filter: filter, current_scope: scope}} = socket
+       ) do
+    branch_id = scope.user.branch_id
+
     sessions =
       case filter do
-        "all" -> Scheduling.list_sessions_for_trainer(trainer.user_id)
-        status -> Scheduling.list_sessions_for_trainer(trainer.user_id, status: status)
+        "all" ->
+          Scheduling.list_sessions_for_trainer(trainer.user_id, branch_id: branch_id)
+
+        status ->
+          Scheduling.list_sessions_for_trainer(trainer.user_id,
+            status: status,
+            branch_id: branch_id
+          )
       end
 
     assign(socket, sessions: sessions)

--- a/lib/gym_studio_web/live/trainer/sessions_live.ex
+++ b/lib/gym_studio_web/live/trainer/sessions_live.ex
@@ -52,7 +52,9 @@ defmodule GymStudioWeb.Trainer.SessionsLive do
   end
 
   def handle_event("confirm_session", %{"session_id" => session_id}, socket) do
-    case Scheduling.confirm_session(session_id) do
+    branch_id = socket.assigns.current_scope.user.branch_id
+
+    case Scheduling.confirm_session(session_id, branch_id: branch_id) do
       {:ok, _session} ->
         {:noreply, socket |> load_sessions() |> put_flash(:info, "Session confirmed.")}
 
@@ -81,7 +83,9 @@ defmodule GymStudioWeb.Trainer.SessionsLive do
         r -> r
       end
 
-    case Scheduling.cancel_session_by_id(session_id, user.id, reason) do
+    case Scheduling.cancel_session_by_id(session_id, user.id, reason,
+           branch_id: socket.assigns.current_scope.user.branch_id
+         ) do
       {:ok, _session} ->
         socket =
           socket
@@ -111,7 +115,9 @@ defmodule GymStudioWeb.Trainer.SessionsLive do
     notes = Map.get(params, "trainer_notes", "")
     attrs = if notes != "", do: %{trainer_notes: notes}, else: %{}
 
-    case Scheduling.complete_session_by_id(session_id, attrs) do
+    case Scheduling.complete_session_by_id(session_id, attrs,
+           branch_id: socket.assigns.current_scope.user.branch_id
+         ) do
       {:ok, _session} ->
         socket =
           socket

--- a/priv/repo/migrations/20260411093000_add_branch_id_to_tables.exs
+++ b/priv/repo/migrations/20260411093000_add_branch_id_to_tables.exs
@@ -58,9 +58,19 @@ defmodule GymStudio.Repo.Migrations.AddBranchIdToTables do
     create index(:training_sessions, [:branch_id])
     create index(:trainer_availabilities, [:branch_id])
     create index(:trainer_time_offs, [:branch_id])
+
+    # 5. Composite indexes for common query patterns
+    create index(:training_sessions, [:branch_id, :status])
+    create index(:training_sessions, [:branch_id, :trainer_id])
+    create index(:session_packages, [:branch_id, :active])
+    create index(:trainer_availabilities, [:branch_id, :trainer_id])
   end
 
   def down do
+    drop index(:trainer_availabilities, [:branch_id, :trainer_id])
+    drop index(:session_packages, [:branch_id, :active])
+    drop index(:training_sessions, [:branch_id, :trainer_id])
+    drop index(:training_sessions, [:branch_id, :status])
     drop index(:trainer_time_offs, [:branch_id])
     drop index(:trainer_availabilities, [:branch_id])
     drop index(:training_sessions, [:branch_id])

--- a/priv/repo/migrations/20260411093000_add_branch_id_to_tables.exs
+++ b/priv/repo/migrations/20260411093000_add_branch_id_to_tables.exs
@@ -1,0 +1,90 @@
+defmodule GymStudio.Repo.Migrations.AddBranchIdToTables do
+  use Ecto.Migration
+
+  def up do
+    # 1. Add nullable branch_id to all target tables
+    alter table(:users) do
+      add :branch_id, references(:branches, on_delete: :restrict), null: true
+    end
+
+    alter table(:session_packages) do
+      add :branch_id, references(:branches, on_delete: :restrict), null: true
+    end
+
+    alter table(:training_sessions) do
+      add :branch_id, references(:branches, on_delete: :restrict), null: true
+    end
+
+    alter table(:trainer_availabilities) do
+      add :branch_id, references(:branches, on_delete: :restrict), null: true
+    end
+
+    alter table(:trainer_time_offs) do
+      add :branch_id, references(:branches, on_delete: :restrict), null: true
+    end
+
+    # 2. Backfill all existing records to Branch 1 (Sin El Fil)
+    # Using execute to run raw SQL for backfill
+    execute "UPDATE users SET branch_id = 1 WHERE branch_id IS NULL"
+    execute "UPDATE session_packages SET branch_id = 1 WHERE branch_id IS NULL"
+    execute "UPDATE training_sessions SET branch_id = 1 WHERE branch_id IS NULL"
+    execute "UPDATE trainer_availabilities SET branch_id = 1 WHERE branch_id IS NULL"
+    execute "UPDATE trainer_time_offs SET branch_id = 1 WHERE branch_id IS NULL"
+
+    # 3. Make branch_id NOT NULL
+    alter table(:users) do
+      modify :branch_id, :bigint, null: false
+    end
+
+    alter table(:session_packages) do
+      modify :branch_id, :bigint, null: false
+    end
+
+    alter table(:training_sessions) do
+      modify :branch_id, :bigint, null: false
+    end
+
+    alter table(:trainer_availabilities) do
+      modify :branch_id, :bigint, null: false
+    end
+
+    alter table(:trainer_time_offs) do
+      modify :branch_id, :bigint, null: false
+    end
+
+    # 4. Add indexes
+    create index(:users, [:branch_id])
+    create index(:session_packages, [:branch_id])
+    create index(:training_sessions, [:branch_id])
+    create index(:trainer_availabilities, [:branch_id])
+    create index(:trainer_time_offs, [:branch_id])
+  end
+
+  def down do
+    drop index(:trainer_time_offs, [:branch_id])
+    drop index(:trainer_availabilities, [:branch_id])
+    drop index(:training_sessions, [:branch_id])
+    drop index(:session_packages, [:branch_id])
+    drop index(:users, [:branch_id])
+
+    alter table(:users) do
+      remove :branch_id
+    end
+
+    alter table(:session_packages) do
+      remove :branch_id
+    end
+
+    alter table(:training_sessions) do
+      remove :branch_id
+    end
+
+    alter table(:trainer_availabilities) do
+      remove :branch_id
+    end
+
+    alter table(:trainer_time_offs) do
+      remove :branch_id
+    end
+  end
+end

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -92,7 +92,8 @@ admin =
     email: "admin@reactgym.com",
     password: "password123456",
     password_confirmation: "password123456",
-    role: :admin
+    role: :admin,
+    branch_id: 1
   })
 
 IO.puts("  Admin created: #{admin.phone_number}")
@@ -109,7 +110,8 @@ trainer1_user =
     email: "john.trainer@reactgym.com",
     password: "password123456",
     password_confirmation: "password123456",
-    role: :trainer
+    role: :trainer,
+    branch_id: 1
   })
 
 trainer1 =
@@ -133,7 +135,8 @@ trainer2_user =
     email: "sarah.trainer@reactgym.com",
     password: "password123456",
     password_confirmation: "password123456",
-    role: :trainer
+    role: :trainer,
+    branch_id: 1
   })
 
 trainer2 =
@@ -157,7 +160,8 @@ trainer3_user =
     email: "mike.trainer@reactgym.com",
     password: "password123456",
     password_confirmation: "password123456",
-    role: :trainer
+    role: :trainer,
+    branch_id: 1
   })
 
 trainer3 =
@@ -183,7 +187,8 @@ client1_user =
     email: "alice@example.com",
     password: "password123456",
     password_confirmation: "password123456",
-    role: :client
+    role: :client,
+    branch_id: 1
   })
 
 client1 =
@@ -205,7 +210,8 @@ client2_user =
     email: "bob@example.com",
     password: "password123456",
     password_confirmation: "password123456",
-    role: :client
+    role: :client,
+    branch_id: 1
   })
 
 client2 =
@@ -227,7 +233,8 @@ client3_user =
     email: "carol@example.com",
     password: "password123456",
     password_confirmation: "password123456",
-    role: :client
+    role: :client,
+    branch_id: 1
   })
 
 client3 =
@@ -254,6 +261,7 @@ package1 =
     client_id: client1_user.id,
     assigned_by_id: admin.id,
     package_type: "standard_12",
+    branch_id: 1,
     expires_at: DateTime.utc_now() |> DateTime.add(60, :day)
   })
   |> Repo.insert!()
@@ -273,6 +281,7 @@ package2 =
     client_id: client2_user.id,
     assigned_by_id: admin.id,
     package_type: "premium_20",
+    branch_id: 1,
     expires_at: DateTime.utc_now() |> DateTime.add(90, :day)
   })
   |> Repo.insert!()
@@ -292,6 +301,7 @@ _package3 =
     client_id: client3_user.id,
     assigned_by_id: admin.id,
     package_type: "standard_8",
+    branch_id: 1,
     expires_at: DateTime.utc_now() |> DateTime.add(-30, :day),
     active: false
   })
@@ -311,6 +321,7 @@ package4 =
     client_id: client3_user.id,
     assigned_by_id: admin.id,
     package_type: "standard_12",
+    branch_id: 1,
     expires_at: DateTime.utc_now() |> DateTime.add(90, :day)
   })
   |> Repo.insert!()
@@ -386,6 +397,7 @@ _session1 =
     scheduled_at: DateTime.utc_now() |> DateTime.add(-7, :day) |> DateTime.truncate(:second),
     duration_minutes: 60,
     status: "completed",
+    branch_id: 1,
     trainer_notes: "Great progress on deadlifts. Increased weight by 10lbs.",
     approved_by_id: admin.id,
     approved_at: DateTime.utc_now() |> DateTime.add(-8, :day) |> DateTime.truncate(:second)
@@ -404,6 +416,7 @@ _session2 =
     scheduled_at: tomorrow,
     duration_minutes: 60,
     status: "confirmed",
+    branch_id: 1,
     approved_by_id: admin.id,
     approved_at: DateTime.utc_now() |> DateTime.truncate(:second)
   })
@@ -419,7 +432,9 @@ _session3 =
     package_id: package2.id,
     scheduled_at: in_3_days,
     duration_minutes: 60,
-    status: "pending"
+    status: "pending",
+    branch_id: 1,
+    branch_id: 1
   })
 
 IO.puts("  Session 3: Bob (pending - in 3 days)")
@@ -435,6 +450,7 @@ _session4 =
     scheduled_at: next_week,
     duration_minutes: 60,
     status: "confirmed",
+    branch_id: 1,
     approved_by_id: admin.id,
     approved_at: DateTime.utc_now() |> DateTime.truncate(:second)
   })
@@ -450,7 +466,9 @@ _session5 =
     package_id: package4.id,
     scheduled_at: in_2_days,
     duration_minutes: 60,
-    status: "pending"
+    status: "pending",
+    branch_id: 1,
+    branch_id: 1
   })
 
 IO.puts("  Session 5: Carol (pending - in 2 days)")
@@ -471,6 +489,7 @@ for trainer_user <- [trainer1_user, trainer2_user] do
       day_of_week: day,
       start_time: ~T[07:00:00],
       end_time: ~T[22:00:00],
+      branch_id: 1,
       active: true
     })
   end
@@ -481,6 +500,7 @@ for trainer_user <- [trainer1_user, trainer2_user] do
     day_of_week: 6,
     start_time: ~T[08:00:00],
     end_time: ~T[13:00:00],
+    branch_id: 1,
     active: true
   })
 

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -433,7 +433,6 @@ _session3 =
     scheduled_at: in_3_days,
     duration_minutes: 60,
     status: "pending",
-    branch_id: 1,
     branch_id: 1
   })
 
@@ -467,7 +466,6 @@ _session5 =
     scheduled_at: in_2_days,
     duration_minutes: 60,
     status: "pending",
-    branch_id: 1,
     branch_id: 1
   })
 

--- a/test/gym_studio/branch_isolation_test.exs
+++ b/test/gym_studio/branch_isolation_test.exs
@@ -1,0 +1,137 @@
+defmodule GymStudio.BranchIsolationTest do
+  use GymStudio.DataCase
+
+  alias GymStudio.{Accounts, BranchesFixtures, Scheduling, SchedulingFixtures}
+  alias GymStudio.AccountsFixtures
+
+  describe "branch data isolation" do
+    setup do
+      branch_a = BranchesFixtures.branch_fixture(%{name: "Branch A"})
+      branch_b = BranchesFixtures.branch_fixture(%{name: "Branch B"})
+
+      # Create users in each branch
+      admin_a = AccountsFixtures.user_fixture(%{role: :admin, branch_id: branch_a.id})
+      admin_b = AccountsFixtures.user_fixture(%{role: :admin, branch_id: branch_b.id})
+      client_a = AccountsFixtures.user_fixture(%{role: :client, branch_id: branch_a.id})
+      client_b = AccountsFixtures.user_fixture(%{role: :client, branch_id: branch_b.id})
+
+      # Create sessions in each branch
+      session_a =
+        SchedulingFixtures.training_session_fixture(%{
+          client_id: client_a.id,
+          branch_id: branch_a.id
+        })
+
+      session_b =
+        SchedulingFixtures.training_session_fixture(%{
+          client_id: client_b.id,
+          branch_id: branch_b.id
+        })
+
+      %{
+        branch_a: branch_a,
+        branch_b: branch_b,
+        admin_a: admin_a,
+        admin_b: admin_b,
+        client_a: client_a,
+        client_b: client_b,
+        session_a: session_a,
+        session_b: session_b
+      }
+    end
+
+    test "list_sessions_for_client filters by branch_id", %{
+      branch_a: branch_a,
+      branch_b: branch_b,
+      client_a: client_a
+    } do
+      sessions_a = Scheduling.list_sessions_for_client(client_a.id, branch_id: branch_a.id)
+      sessions_b = Scheduling.list_sessions_for_client(client_a.id, branch_id: branch_b.id)
+
+      assert length(sessions_a) >= 1
+      assert Enum.all?(sessions_a, &(&1.branch_id == branch_a.id))
+      assert sessions_b == []
+    end
+
+    test "list_pending_sessions filters by branch_id", %{
+      branch_a: branch_a,
+      branch_b: branch_b
+    } do
+      pending_a = Scheduling.list_pending_sessions(branch_id: branch_a.id)
+      pending_b = Scheduling.list_pending_sessions(branch_id: branch_b.id)
+
+      assert Enum.all?(pending_a, &(&1.branch_id == branch_a.id))
+      assert Enum.all?(pending_b, &(&1.branch_id == branch_b.id))
+    end
+
+    test "list_all_sessions filters by branch_id", %{
+      branch_a: branch_a,
+      branch_b: branch_b
+    } do
+      all_a = Scheduling.list_all_sessions(branch_id: branch_a.id)
+      all_b = Scheduling.list_all_sessions(branch_id: branch_b.id)
+
+      assert Enum.all?(all_a, &(&1.branch_id == branch_a.id))
+      assert Enum.all?(all_b, &(&1.branch_id == branch_b.id))
+      # No overlap
+      ids_a = MapSet.new(all_a, & &1.id)
+      ids_b = MapSet.new(all_b, & &1.id)
+      assert MapSet.disjoint?(ids_a, ids_b)
+    end
+
+    test "list_users filters by branch_id", %{
+      branch_a: branch_a,
+      branch_b: branch_b
+    } do
+      users_a = Accounts.list_users(branch_id: branch_a.id)
+      users_b = Accounts.list_users(branch_id: branch_b.id)
+
+      assert Enum.all?(users_a, &(&1.branch_id == branch_a.id))
+      assert Enum.all?(users_b, &(&1.branch_id == branch_b.id))
+
+      ids_a = MapSet.new(users_a, & &1.id)
+      ids_b = MapSet.new(users_b, & &1.id)
+      assert MapSet.disjoint?(ids_a, ids_b)
+    end
+
+    test "session mutation rejects cross-branch modification", %{
+      branch_a: branch_a,
+      session_b: session_b
+    } do
+      # Try to complete a session from branch B using branch A's ID
+      assert {:error, :wrong_branch} ==
+               Scheduling.complete_session(session_b, %{}, branch_id: branch_a.id)
+    end
+
+    test "cancel_session rejects cross-branch modification", %{
+      branch_a: branch_a,
+      session_b: session_b,
+      admin_a: admin_a
+    } do
+      assert {:error, :wrong_branch} ==
+               Scheduling.cancel_session(session_b, admin_a.id, "test", branch_id: branch_a.id)
+    end
+
+    test "mark_no_show rejects cross-branch modification", %{
+      branch_a: branch_a,
+      session_b: session_b
+    } do
+      assert {:error, :wrong_branch} ==
+               Scheduling.mark_no_show(session_b, branch_id: branch_a.id)
+    end
+
+    test "count_sessions_by_status is isolated by branch", %{
+      branch_a: branch_a,
+      branch_b: branch_b
+    } do
+      counts_a = Scheduling.count_sessions_by_status(branch_id: branch_a.id)
+      counts_b = Scheduling.count_sessions_by_status(branch_id: branch_b.id)
+
+      # Each branch should see at least its own sessions
+      total_a = counts_a |> Map.values() |> Enum.sum()
+      total_b = counts_b |> Map.values() |> Enum.sum()
+      assert total_a >= 1
+      assert total_b >= 1
+    end
+  end
+end

--- a/test/gym_studio/packages_test.exs
+++ b/test/gym_studio/packages_test.exs
@@ -94,7 +94,8 @@ defmodule GymStudio.PackagesTest do
       attrs = %{
         client_id: Ecto.UUID.generate(),
         package_type: "standard_8",
-        assigned_by_id: admin.id
+        assigned_by_id: admin.id,
+        branch_id: admin.branch_id
       }
 
       assert {:error, %Ecto.Changeset{} = changeset} = Packages.assign_package(attrs)

--- a/test/gym_studio/scheduling/available_slots_test.exs
+++ b/test/gym_studio/scheduling/available_slots_test.exs
@@ -4,6 +4,8 @@ defmodule GymStudio.Scheduling.AvailableSlotsTest do
   alias GymStudio.Scheduling
 
   setup do
+    branch = GymStudio.BranchesFixtures.branch_fixture()
+
     trainer =
       %GymStudio.Accounts.User{}
       |> GymStudio.Accounts.User.registration_changeset(%{
@@ -12,7 +14,8 @@ defmodule GymStudio.Scheduling.AvailableSlotsTest do
         email: "slots_test@test.com",
         password: "password123456",
         password_confirmation: "password123456",
-        role: :trainer
+        role: :trainer,
+        branch_id: branch.id
       })
       |> GymStudio.Accounts.User.confirm_changeset()
       |> GymStudio.Repo.insert!()
@@ -25,7 +28,8 @@ defmodule GymStudio.Scheduling.AvailableSlotsTest do
         email: "slots_client@test.com",
         password: "password123456",
         password_confirmation: "password123456",
-        role: :client
+        role: :client,
+        branch_id: branch.id
       })
       |> GymStudio.Accounts.User.confirm_changeset()
       |> GymStudio.Repo.insert!()
@@ -73,7 +77,8 @@ defmodule GymStudio.Scheduling.AvailableSlotsTest do
         trainer_id: trainer.id,
         scheduled_at: scheduled_at,
         duration_minutes: 60,
-        status: "confirmed"
+        status: "confirmed",
+        branch_id: trainer.branch_id
       })
 
       slots = Scheduling.get_trainer_available_slots(trainer.id, monday)

--- a/test/gym_studio/scheduling/trainer_availability_test.exs
+++ b/test/gym_studio/scheduling/trainer_availability_test.exs
@@ -5,6 +5,8 @@ defmodule GymStudio.Scheduling.TrainerAvailabilityTest do
   alias GymStudio.Scheduling.TrainerAvailability
 
   setup do
+    branch = GymStudio.BranchesFixtures.branch_fixture()
+
     user =
       %GymStudio.Accounts.User{}
       |> GymStudio.Accounts.User.registration_changeset(%{
@@ -13,46 +15,50 @@ defmodule GymStudio.Scheduling.TrainerAvailabilityTest do
         email: "avail_test@test.com",
         password: "password123456",
         password_confirmation: "password123456",
-        role: :trainer
+        role: :trainer,
+        branch_id: branch.id
       })
       |> GymStudio.Accounts.User.confirm_changeset()
       |> GymStudio.Repo.insert!()
 
-    %{trainer: user}
+    %{trainer: user, branch: branch}
   end
 
   describe "TrainerAvailability schema" do
-    test "valid changeset", %{trainer: trainer} do
+    test "valid changeset", %{trainer: trainer, branch: branch} do
       changeset =
         TrainerAvailability.changeset(%TrainerAvailability{}, %{
           trainer_id: trainer.id,
           day_of_week: 1,
           start_time: ~T[07:00:00],
-          end_time: ~T[22:00:00]
+          end_time: ~T[22:00:00],
+          branch_id: branch.id
         })
 
       assert changeset.valid?
     end
 
-    test "invalid day_of_week", %{trainer: trainer} do
+    test "invalid day_of_week", %{trainer: trainer, branch: branch} do
       changeset =
         TrainerAvailability.changeset(%TrainerAvailability{}, %{
           trainer_id: trainer.id,
           day_of_week: 8,
           start_time: ~T[07:00:00],
-          end_time: ~T[22:00:00]
+          end_time: ~T[22:00:00],
+          branch_id: branch.id
         })
 
       refute changeset.valid?
     end
 
-    test "end_time must be after start_time", %{trainer: trainer} do
+    test "end_time must be after start_time", %{trainer: trainer, branch: branch} do
       changeset =
         TrainerAvailability.changeset(%TrainerAvailability{}, %{
           trainer_id: trainer.id,
           day_of_week: 1,
           start_time: ~T[22:00:00],
-          end_time: ~T[07:00:00]
+          end_time: ~T[07:00:00],
+          branch_id: branch.id
         })
 
       refute changeset.valid?

--- a/test/gym_studio/scheduling/trainer_time_off_test.exs
+++ b/test/gym_studio/scheduling/trainer_time_off_test.exs
@@ -5,6 +5,8 @@ defmodule GymStudio.Scheduling.TrainerTimeOffTest do
   alias GymStudio.Scheduling.TrainerTimeOff
 
   setup do
+    branch = GymStudio.BranchesFixtures.branch_fixture()
+
     user =
       %GymStudio.Accounts.User{}
       |> GymStudio.Accounts.User.registration_changeset(%{
@@ -13,43 +15,47 @@ defmodule GymStudio.Scheduling.TrainerTimeOffTest do
         email: "timeoff_test@test.com",
         password: "password123456",
         password_confirmation: "password123456",
-        role: :trainer
+        role: :trainer,
+        branch_id: branch.id
       })
       |> GymStudio.Accounts.User.confirm_changeset()
       |> GymStudio.Repo.insert!()
 
-    %{trainer: user}
+    %{trainer: user, branch: branch}
   end
 
   describe "TrainerTimeOff schema" do
-    test "valid all-day changeset", %{trainer: trainer} do
+    test "valid all-day changeset", %{trainer: trainer, branch: branch} do
       changeset =
         TrainerTimeOff.changeset(%TrainerTimeOff{}, %{
           trainer_id: trainer.id,
-          date: ~D[2026-04-01]
+          date: ~D[2026-04-01],
+          branch_id: branch.id
         })
 
       assert changeset.valid?
     end
 
-    test "valid partial-day changeset", %{trainer: trainer} do
+    test "valid partial-day changeset", %{trainer: trainer, branch: branch} do
       changeset =
         TrainerTimeOff.changeset(%TrainerTimeOff{}, %{
           trainer_id: trainer.id,
           date: ~D[2026-04-01],
           start_time: ~T[09:00:00],
-          end_time: ~T[12:00:00]
+          end_time: ~T[12:00:00],
+          branch_id: branch.id
         })
 
       assert changeset.valid?
     end
 
-    test "invalid when only start_time set", %{trainer: trainer} do
+    test "invalid when only start_time set", %{trainer: trainer, branch: branch} do
       changeset =
         TrainerTimeOff.changeset(%TrainerTimeOff{}, %{
           trainer_id: trainer.id,
           date: ~D[2026-04-01],
-          start_time: ~T[09:00:00]
+          start_time: ~T[09:00:00],
+          branch_id: branch.id
         })
 
       refute changeset.valid?

--- a/test/gym_studio_web/live/registration_live_test.exs
+++ b/test/gym_studio_web/live/registration_live_test.exs
@@ -112,6 +112,11 @@ defmodule GymStudioWeb.RegistrationLiveTest do
   end
 
   describe "Full registration flow" do
+    setup do
+      # Branch is required for registration (branch_id is NOT NULL)
+      _branch = GymStudio.BranchesFixtures.branch_fixture()
+      :ok
+    end
     test "completes registration with valid data", %{conn: conn} do
       phone =
         "71#{System.unique_integer([:positive]) |> rem(10_000_000) |> Integer.to_string() |> String.pad_leading(7, "0")}"

--- a/test/gym_studio_web/live/registration_live_test.exs
+++ b/test/gym_studio_web/live/registration_live_test.exs
@@ -117,6 +117,7 @@ defmodule GymStudioWeb.RegistrationLiveTest do
       _branch = GymStudio.BranchesFixtures.branch_fixture()
       :ok
     end
+
     test "completes registration with valid data", %{conn: conn} do
       phone =
         "71#{System.unique_integer([:positive]) |> rem(10_000_000) |> Integer.to_string() |> String.pad_leading(7, "0")}"

--- a/test/support/fixtures/accounts_fixtures.ex
+++ b/test/support/fixtures/accounts_fixtures.ex
@@ -17,13 +17,36 @@ defmodule GymStudio.AccountsFixtures do
   def valid_user_password, do: "hello world!"
 
   def valid_user_attributes(attrs \\ %{}) do
+    # Convert keyword list to map if needed
+    attrs = Enum.into(attrs, %{})
+    branch_id = Map.get(attrs, :branch_id) || ensure_test_branch()
+
     Enum.into(attrs, %{
       name: "Test User #{System.unique_integer([:positive])}",
       email: unique_user_email(),
       phone_number: unique_phone_number(),
       password: valid_user_password(),
-      password_confirmation: valid_user_password()
+      password_confirmation: valid_user_password(),
+      branch_id: branch_id
     })
+  end
+
+  defp ensure_test_branch do
+    case GymStudio.Branches.list_branches() do
+      [branch | _] ->
+        branch.id
+
+      [] ->
+        {:ok, branch} =
+          GymStudio.Branches.create_branch(%{
+            name: "Default Test Branch",
+            slug: "test-branch-#{System.unique_integer([:positive])}",
+            capacity: 4,
+            active: true
+          })
+
+        branch.id
+    end
   end
 
   def unconfirmed_user_fixture(attrs \\ %{}) do

--- a/test/support/fixtures/branches_fixtures.ex
+++ b/test/support/fixtures/branches_fixtures.ex
@@ -1,0 +1,39 @@
+defmodule GymStudio.BranchesFixtures do
+  @moduledoc """
+  Test fixtures for the Branches context.
+  """
+
+  alias GymStudio.Branches
+
+  @doc """
+  Generate a branch.
+
+  ## Options
+
+    - `:name` - Branch name (default: "Test Branch")
+    - `:slug` - Branch slug (default: "test-branch-{unique}")
+    - `:capacity` - Branch capacity (default: 4)
+
+  ## Examples
+
+      iex> branch_fixture()
+      %Branch{}
+
+      iex> branch_fixture(%{name: "Sin El Fil"})
+      %Branch{}
+  """
+  def branch_fixture(attrs \\ %{}) do
+    unique = System.unique_integer([:positive])
+
+    attrs =
+      Enum.into(attrs, %{
+        name: "Test Branch #{unique}",
+        slug: "test-branch-#{unique}",
+        capacity: 4,
+        active: true
+      })
+
+    {:ok, branch} = Branches.create_branch(attrs)
+    branch
+  end
+end

--- a/test/support/fixtures/packages_fixtures.ex
+++ b/test/support/fixtures/packages_fixtures.ex
@@ -18,27 +18,48 @@ defmodule GymStudio.PackagesFixtures do
     - `:expires_at` - Expiration datetime (default: nil)
     - `:notes` - Package notes (default: nil)
     - `:active` - Active status (default: true)
+    - `:branch_id` - The branch ID (required)
 
   ## Examples
 
-      iex> client = user_fixture(role: :client)
-      iex> admin = user_fixture(role: :admin)
-      iex> package_fixture(client_id: client.id, assigned_by_id: admin.id)
+      iex> package_fixture(client_id: client.id, assigned_by_id: admin.id, branch_id: branch.id)
       %SessionPackage{}
 
       iex> package_fixture(
       ...>   client_id: client.id,
       ...>   assigned_by_id: admin.id,
-      ...>   package_type: "premium_20"
+      ...>   package_type: "premium_20",
+      ...>   branch_id: branch.id
       ...> )
       %SessionPackage{}
   """
   def package_fixture(attrs \\ %{}) do
+    # Auto-fill branch_id from client or assigned_by user if not provided
+    branch_id =
+      attrs[:branch_id] ||
+        if attrs[:client_id] do
+          client = GymStudio.Accounts.get_user!(attrs[:client_id])
+          client.branch_id
+        else
+          if attrs[:assigned_by_id] do
+            admin = GymStudio.Accounts.get_user!(attrs[:assigned_by_id])
+            admin.branch_id
+          else
+            nil
+          end
+        end
+
     attrs =
-      Enum.into(attrs, %{
+      attrs
+      |> Enum.into(%{
         package_type: "standard_8",
         active: true
       })
+      |> then(fn a ->
+        if branch_id && !Map.has_key?(a, :branch_id),
+          do: Map.put(a, :branch_id, branch_id),
+          else: a
+      end)
 
     {:ok, package} = Packages.assign_package(attrs)
     package
@@ -53,6 +74,7 @@ defmodule GymStudio.PackagesFixtures do
     - `:assigned_by_id` - The ID of the admin user (required)
     - `:package_type` - Package type (default: "standard_8")
     - `:used_sessions` - Number of sessions to mark as used (default: 3)
+    - `:branch_id` - The branch ID (required)
     - Additional options from `package_fixture/1`
 
   ## Examples
@@ -60,7 +82,8 @@ defmodule GymStudio.PackagesFixtures do
       iex> used_package_fixture(
       ...>   client_id: client.id,
       ...>   assigned_by_id: admin.id,
-      ...>   used_sessions: 5
+      ...>   used_sessions: 5,
+      ...>   branch_id: branch.id
       ...> )
       %SessionPackage{used_sessions: 5}
   """
@@ -84,11 +107,12 @@ defmodule GymStudio.PackagesFixtures do
     - `:client_id` - The ID of the client user (required)
     - `:assigned_by_id` - The ID of the admin user (required)
     - `:package_type` - Package type (default: "standard_8")
+    - `:branch_id` - The branch ID (required)
     - Additional options from `package_fixture/1`
 
   ## Examples
 
-      iex> expired_package_fixture(client_id: client.id, assigned_by_id: admin.id)
+      iex> expired_package_fixture(client_id: client.id, assigned_by_id: admin.id, branch_id: branch.id)
       %SessionPackage{expires_at: ~U[...]}
   """
   def expired_package_fixture(attrs \\ %{}) do
@@ -109,11 +133,12 @@ defmodule GymStudio.PackagesFixtures do
     - `:client_id` - The ID of the client user (required)
     - `:assigned_by_id` - The ID of the admin user (required)
     - `:package_type` - Package type (default: "standard_8")
+    - `:branch_id` - The branch ID (required)
     - Additional options from `package_fixture/1`
 
   ## Examples
 
-      iex> fully_used_package_fixture(client_id: client.id, assigned_by_id: admin.id)
+      iex> fully_used_package_fixture(client_id: client.id, assigned_by_id: admin.id, branch_id: branch.id)
       %SessionPackage{used_sessions: 8, total_sessions: 8}
   """
   def fully_used_package_fixture(attrs \\ %{}) do
@@ -134,11 +159,12 @@ defmodule GymStudio.PackagesFixtures do
     - `:client_id` - The ID of the client user (required)
     - `:assigned_by_id` - The ID of the admin user (required)
     - `:package_type` - Package type (default: "standard_8")
+    - `:branch_id` - The branch ID (required)
     - Additional options from `package_fixture/1`
 
   ## Examples
 
-      iex> inactive_package_fixture(client_id: client.id, assigned_by_id: admin.id)
+      iex> inactive_package_fixture(client_id: client.id, assigned_by_id: admin.id, branch_id: branch.id)
       %SessionPackage{active: false}
   """
   def inactive_package_fixture(attrs \\ %{}) do

--- a/test/support/fixtures/scheduling_fixtures.ex
+++ b/test/support/fixtures/scheduling_fixtures.ex
@@ -16,13 +16,14 @@ defmodule GymStudio.SchedulingFixtures do
   - `:duration_minutes` - Optional. Defaults to 60.
   - `:status` - Optional. Defaults to "pending".
   - `:notes` - Optional. Client notes.
+  - `:branch_id` - Optional. The branch ID for the session.
 
   ## Examples
 
-      iex> training_session_fixture(%{client_id: client.id})
+      iex> training_session_fixture(%{client_id: client.id, branch_id: branch.id})
       %TrainingSession{}
 
-      iex> training_session_fixture(%{client_id: client.id, status: "confirmed", trainer_id: trainer.id})
+      iex> training_session_fixture(%{client_id: client.id, status: "confirmed", trainer_id: trainer.id, branch_id: branch.id})
       %TrainingSession{}
   """
   def training_session_fixture(attrs \\ %{}) do
@@ -33,10 +34,21 @@ defmodule GymStudio.SchedulingFixtures do
         |> DateTime.add(System.unique_integer([:positive, :monotonic]), :second)
         |> DateTime.truncate(:second)
 
+    # Get branch_id from client if not provided
+    branch_id =
+      attrs[:branch_id] ||
+        if attrs[:client_id] do
+          client = GymStudio.Accounts.get_user!(attrs[:client_id])
+          client.branch_id
+        else
+          nil
+        end
+
     base_attrs = %{
       scheduled_at: scheduled_at,
       duration_minutes: 60,
-      notes: "Test session notes"
+      notes: "Test session notes",
+      branch_id: branch_id
     }
 
     attrs = Map.merge(base_attrs, Enum.into(attrs, %{}))
@@ -70,13 +82,15 @@ defmodule GymStudio.SchedulingFixtures do
   - `:approved_by_id` - Required. The ID of the user who approved it.
   - `:scheduled_at` - Optional. Defaults to tomorrow at 10:00 UTC.
   - `:duration_minutes` - Optional. Defaults to 60.
+  - `:branch_id` - Optional. The branch ID for the session.
 
   ## Examples
 
       iex> confirmed_session_fixture(%{
       ...>   client_id: client.id,
       ...>   trainer_id: trainer.id,
-      ...>   approved_by_id: admin.id
+      ...>   approved_by_id: admin.id,
+      ...>   branch_id: branch.id
       ...> })
       %TrainingSession{}
   """


### PR DESCRIPTION
## Summary

Implements GitHub Issue #66 — the core multi-branch migration.

### Migration
- Add nullable `branch_id` to: `users`, `session_packages`, `training_sessions`, `trainer_availabilities`, `trainer_time_offs`
- Backfill all existing records to Branch 1 (Sin El Fil)
- Make `branch_id` NOT NULL with foreign key + indexes
- Does **NOT** add `branch_id` to: `exercise_library`, `goals`, `body_metrics`, `exercise_logs`, `notifications` (branch-agnostic)

### Schema Changes
- Add `belongs_to :branch` (type: `:integer`) to all 5 schemas
- Update changesets to require/cast `branch_id`
- Use `type: :integer` since branches table uses integer PK while other tables use binary_id

### Query Scoping
- **Accounts**: `list_users`, `list_clients`, `list_trainers`, `search_users`, `count_users_by_role` all accept `branch_id` option
- **Scheduling**: `list_sessions_for_client/trainer`, `list_pending_sessions`, `list_upcoming_sessions`, `list_all_sessions`, analytics queries all accept `branch_id` option
- **Packages**: `list_packages_for_client`, `list_all_packages`, `get_active_package_for_client` all accept `branch_id` option
- Auto-fill `branch_id` from user when not provided in `book_session`, `assign_package`, `set_trainer_availability`, `create_time_off`

### LiveView Updates
- All admin LiveViews scope by current user's `branch_id`
- All client/trainer LiveViews scope by current user's `branch_id`
- Registration flow defaults to first active branch
- Scope module updated to carry `branch_id`

### Branches Context
- Added `get_default_branch/0` for registration flow

### Tests
- Created `branches_fixtures.ex` with `branch_fixture/1`
- Updated `accounts_fixtures` to include `branch_id`
- Updated `scheduling_fixtures` and `packages_fixtures` to auto-fill `branch_id`
- Updated direct-schema tests to include `branch_id`
- **486/495 tests pass** (9 pre-existing failures from missing Telnyx credentials)

## Test Plan
- [x] `mix format --check-formatted` ✅
- [x] `mix compile --warnings-as-errors` ✅
- [x] `mix test` — 486 pass, 9 fail (pre-existing Telnyx issues) ✅

Closes #66