### PR TITLE
fix: Remove double query= encoding in Google Maps directions link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.2.1] - 2026-04-12
+
+### Fixed
+- Google Maps directions link was double-encoding `query=` parameter, breaking the URL (#78)
+
+## [0.2.0] - 2026-04-12
 
 ### Added
 - Landing page "Our Locations" section — dynamic branch cards with address, phone, hours, and Google Maps directions (#69)

--- a/lib/gym_studio_web/controllers/page_html/home.html.heex
+++ b/lib/gym_studio_web/controllers/page_html/home.html.heex
@@ -733,7 +733,7 @@
             <%= if branch.latitude && branch.longitude do %>
               <div class="mt-5 pt-4 border-t border-gray-100">
                 <a
-                  href={"https://www.google.com/maps/search/?api=1&query=#{URI.encode_query(%{query: "#{branch.latitude},#{branch.longitude}"})}"}
+                  href={"https://www.google.com/maps/search/?api=1&query=#{URI.encode_www_form("#{branch.latitude},#{branch.longitude}")}"}
                   target="_blank"
                   rel="noopener noreferrer"
                   class="inline-flex items-center gap-2 text-primary font-medium text-sm hover:underline"

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule GymStudio.MixProject do
   def project do
     [
       app: :gym_studio,
-      version: "0.2.0",
+      version: "0.2.1",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## Problem

The "Get Directions" link on the landing page generates a broken Google Maps URL.

**Before:** `https://www.google.com/maps/search/?api=1&query=query%3D33.8734%2C35.5254`
**After:** `https://www.google.com/maps/search/?api=1&query=33.8734%2C35.5254`

## Root Cause

`URI.encode_query(%{query: "..."})` produces `query=...` — so when you also interpolate it after `&query=`, you get `query=query%3D...` (double-encoded).

## Fix

Use `URI.encode_www_form/1` to encode just the coordinate value, not the whole key-value pair.

Fixes the location link reported by Zaher.