### PR TITLE
fix(#83): Review fixes for client/trainer bottom nav

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.0] - 2026-04-19
+
+### Added
+- Glass bottom navigation bar for mobile clients — frosted glass effect, 5-tab layout with pulse FAB for booking (#79, #80, #84)
+- Horizontal wordmark logos for navbar, hero, and footer sections (#82)
+- Trainer/admin bottom navigation bar with role-specific tabs
+- `aria-label` on all navigation tabs for accessibility
+- LiveView `navigate` links for SPA-style page transitions (no full reloads)
+- Role-specific body padding: `pb-24` for client, `pb-20` for trainer/admin
+- iOS safe area support via `env(safe-area-inset-bottom)` on mobile nav
+- Pulse animation on booking FAB (plays 3 times then stops)
+
+### Changed
+- Replaced old R-icon + "REACT" text with horizontal wordmark SVGs across all layouts
+- Removed unused logo assets (20 → 8 files kept)
+- Tab label font size increased to 11px for better mobile readability
+
+### Fixed
+- Bottom content no longer hidden behind fixed mobile nav bar
+- Active tab indicator now uses DaisyUI `text-primary` / `text-base-content` tokens (theme-aware)
+
 ## [0.2.1] - 2026-04-12
 
 ### Fixed

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -156,6 +156,8 @@
   100% { box-shadow: 0 0 0 0 rgba(230, 57, 70, 0), 0 4px 16px rgba(230, 57, 70, 0.35); }
 }
 
-.animate-booking-pulse {
-  animation: booking-pulse 2.2s ease-out 3;
+@media (prefers-reduced-motion: no-preference) {
+  .animate-booking-pulse {
+    animation: booking-pulse 2.2s ease-out 3;
+  }
 }

--- a/lib/gym_studio_web/components/layouts.ex
+++ b/lib/gym_studio_web/components/layouts.ex
@@ -42,7 +42,7 @@ defmodule GymStudioWeb.Layouts do
                 class="flex items-center justify-center w-[62px] h-[62px] rounded-full text-white animate-booking-pulse transition-transform duration-200 hover:scale-110 active:scale-95"
                 style="background: linear-gradient(135deg, #E63946, #C72F3C); box-shadow: 0 4px 16px rgba(230, 57, 70, 0.35);"
               >
-                <.icon name="hero-plus" class="size-7" />
+                <span aria-hidden="true"><.icon name="hero-plus" class="size-7" /></span>
               </span>
             </.link>
           <% else %>
@@ -52,8 +52,8 @@ defmodule GymStudioWeb.Layouts do
               class={[
                 "flex items-center justify-center p-3 transition-all duration-200",
                 if(tab_active?(@current_path, tab.path),
-                  do: "text-[#1a1a1a]",
-                  else: "text-[#9ca3af]"
+                  do: "text-base-content",
+                  else: "text-base-content/40"
                 )
               ]}
               style={
@@ -76,12 +76,15 @@ defmodule GymStudioWeb.Layouts do
     assigns = assign(assigns, :tabs, tabs_for_role(assigns.current_scope.user.role))
 
     ~H"""
-    <nav class="fixed bottom-0 inset-x-0 z-50 bg-base-100 border-t border-base-300 pb-[env(safe-area-inset-bottom)] md:hidden">
-      <div class="flex items-end justify-around h-16 px-2">
+    <nav
+      class="fixed bottom-0 inset-x-0 z-50 bg-base-100 border-t border-base-300 md:hidden"
+      style="padding-bottom: env(safe-area-inset-bottom);"
+    >
+      <div class="flex items-center justify-around h-18 px-2">
         <%= for tab <- @tabs do %>
           <%= if tab.fab do %>
             <.link
-              href={tab.path}
+              navigate={tab.path}
               class="flex flex-col items-center justify-center -mt-6"
               aria-label={tab.label}
             >
@@ -91,9 +94,10 @@ defmodule GymStudioWeb.Layouts do
             </.link>
           <% else %>
             <.link
-              href={tab.path}
+              navigate={tab.path}
+              aria-label={tab.label}
               class={[
-                "flex flex-col items-center justify-center gap-0.5 py-2 px-3 rounded-lg transition-colors duration-200 min-w-[4rem]",
+                "flex flex-col items-center justify-center gap-1 py-2 px-3 rounded-lg transition-colors duration-200 min-w-[4rem]",
                 if(tab_active?(@current_path, tab.path),
                   do: "text-primary",
                   else: "text-gray-500 hover:text-gray-700"
@@ -101,7 +105,7 @@ defmodule GymStudioWeb.Layouts do
               ]}
             >
               <.icon name={tab.icon} class="size-6" />
-              <span class="text-[10px] font-medium leading-tight">{tab.label}</span>
+              <span class="text-[11px] font-medium leading-tight">{tab.label}</span>
               <%= if tab_active?(@current_path, tab.path) do %>
                 <span class="w-1 h-1 rounded-full bg-primary mt-0.5"></span>
               <% end %>
@@ -131,7 +135,6 @@ defmodule GymStudioWeb.Layouts do
       },
       %{
         icon: "hero-plus",
-        active_icon: "hero-plus",
         label: "Book",
         path: ~p"/client/book",
         fab: true

--- a/lib/gym_studio_web/components/layouts/root.html.heex
+++ b/lib/gym_studio_web/components/layouts/root.html.heex
@@ -93,7 +93,11 @@
       })();
     </script>
   </head>
-  <body class={["bg-base-100", @current_scope && "pb-24 md:pb-0"]}>
+  <body class={[
+    "bg-base-100",
+    @current_scope &&
+      if(@current_scope.user.role == :client, do: "pb-24 md:pb-0", else: "pb-20 md:pb-0")
+  ]}>
     <%!-- Modern Navigation Header --%>
     <header class="sticky top-0 z-50 bg-white/95 backdrop-blur-sm border-b border-base-300/50 shadow-sm">
       <nav class="container mx-auto px-4 sm:px-6 lg:px-8">

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule GymStudio.MixProject do
   def project do
     [
       app: :gym_studio,
-      version: "0.2.1",
+      version: "0.3.0",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/gym_studio_web/components/layouts_test.exs
+++ b/test/gym_studio_web/components/layouts_test.exs
@@ -80,9 +80,9 @@ defmodule GymStudioWeb.LayoutsTest do
           current_path: "/client"
         )
 
-      # Home tab should be active — uses solid icon and near-black color
+      # Home tab should be active — uses solid icon and base-content color
       assert html =~ "hero-home-solid"
-      assert html =~ "text-[#1a1a1a]"
+      assert html =~ "text-base-content"
     end
 
     test "highlights active tab for client on sessions" do
@@ -128,8 +128,8 @@ defmodule GymStudioWeb.LayoutsTest do
       [before_progress, _after] = String.split(html, ~s(href="/client/progress"), parts: 2)
       [_before_home, home_section] = String.split(before_progress, ~s(href="/client"), parts: 2)
 
-      # Home tab section should have inactive gray color
-      assert home_section =~ "text-[#9ca3af]"
+      # Home tab section should have inactive color
+      assert home_section =~ "text-base-content/40"
     end
 
     test "nav is hidden on md breakpoint and above" do
@@ -188,6 +188,109 @@ defmodule GymStudioWeb.LayoutsTest do
           current_path: "/client"
         )
 
+      assert html =~ "safe-area-inset-bottom"
+    end
+
+    test "nav landmark element is present" do
+      for role <- [:client, :trainer, :admin] do
+        user = user_fixture(%{role: role})
+        scope = user_scope_fixture(user)
+
+        html =
+          render_component(&Layouts.mobile_bottom_nav/1,
+            current_scope: scope,
+            current_path: "/"
+          )
+
+        assert html =~ ~s(<nav)
+      end
+    end
+
+    test "aria-label attributes exist on all tab links for client" do
+      user = user_fixture(%{role: :client})
+      scope = user_scope_fixture(user)
+
+      html =
+        render_component(&Layouts.mobile_bottom_nav/1,
+          current_scope: scope,
+          current_path: "/client"
+        )
+
+      for label <- ["Home", "Progress", "Book", "Schedule", "Profile"] do
+        assert html =~ ~s(aria-label="#{label}")
+      end
+    end
+
+    test "aria-label attributes exist on all tab links for trainer" do
+      user = user_fixture(%{role: :trainer})
+      scope = user_scope_fixture(user)
+
+      html =
+        render_component(&Layouts.mobile_bottom_nav/1,
+          current_scope: scope,
+          current_path: "/trainer"
+        )
+
+      for label <- ["Home", "Clients", "Session", "Schedule", "Profile"] do
+        assert html =~ ~s(aria-label="#{label}")
+      end
+    end
+
+    test "client nav uses SPA-style navigation (data-phx-link)" do
+      user = user_fixture(%{role: :client})
+      scope = user_scope_fixture(user)
+
+      html =
+        render_component(&Layouts.mobile_bottom_nav/1,
+          current_scope: scope,
+          current_path: "/client"
+        )
+
+      # navigate links render with data-phx-link="redirect"
+      assert html =~ ~s(data-phx-link="redirect")
+    end
+
+    test "trainer nav uses SPA-style navigation (data-phx-link)" do
+      user = user_fixture(%{role: :trainer})
+      scope = user_scope_fixture(user)
+
+      html =
+        render_component(&Layouts.mobile_bottom_nav/1,
+          current_scope: scope,
+          current_path: "/trainer"
+        )
+
+      assert html =~ ~s(data-phx-link="redirect")
+    end
+
+    test "FAB icon has aria-hidden" do
+      user = user_fixture(%{role: :client})
+      scope = user_scope_fixture(user)
+
+      html =
+        render_component(&Layouts.mobile_bottom_nav/1,
+          current_scope: scope,
+          current_path: "/client"
+        )
+
+      # The hero-plus icon inside the FAB should be aria-hidden
+      assert html =~ ~s(aria-hidden="true")
+    end
+
+    test "trainer nav has centered items and safe area" do
+      user = user_fixture(%{role: :trainer})
+      scope = user_scope_fixture(user)
+
+      html =
+        render_component(&Layouts.mobile_bottom_nav/1,
+          current_scope: scope,
+          current_path: "/trainer"
+        )
+
+      # Items should be centered vertically, not bottom-aligned
+      assert html =~ "items-center"
+      refute html =~ "items-end"
+      # Safe area padding via style attribute
       assert html =~ "safe-area-inset-bottom"
     end
   end


### PR DESCRIPTION
## Fixes from Code Review (commit 65e29d1)

- **W1: Unify `navigate` vs `href`** — Trainer/admin nav now uses `navigate` for consistent SPA-style LiveView navigation
- **W2: Replace hardcoded colors with daisyUI theme tokens** — `text-[#1a1a1a]` → `text-base-content`, `text-[#9ca3af]` → `text-base-content/40`
- **W3: Add `prefers-reduced-motion` guard** — Pulse animation only runs when user has no motion preference
- **W4: Add `aria-hidden` on FAB icon** — Prevents screen reader redundancy (link already has `aria-label`)
- **I4: Remove unused `active_icon` key** — FAB tab no longer has `active_icon: "hero-plus"`

## Fixes from UI Feedback

- **Trainer nav readability** — `items-end` → `items-center`, `h-16` → `h-18`, `gap-0.5` → `gap-1`, `text-[10px]` → `text-[11px]`
- **Safe area padding** — Trainer nav uses `style="padding-bottom: env(safe-area-inset-bottom);"` (Tailwind class unreliable for env())
- **I6: Scope body padding** — `pb-24 md:pb-0` for client, `pb-20 md:pb-0` for trainer/admin

## New Tests Added

- `aria-label` attributes on all tab links (client + trainer)
- `<nav>` landmark element presence
- SPA-style navigation (`data-phx-link="redirect"`) for client and trainer
- FAB icon `aria-hidden`
- Trainer nav centered items and safe area

## Checklist

- [x] `mix format --check-formatted` ✅
- [x] `mix compile --warnings-as-errors` ✅
- [x] `mix test` — 596 tests, 0 failures ✅

Closes #83