### PR TITLE
fix: MobileBottomNav active tab not updating on navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.1] - 2026-04-19
+
+### Fixed
+- Mobile bottom nav active tab not updating on LiveView navigation (#90)
+  - Changed JS hook to listen for `phx:page-loading-stop` instead of `phx:navigated`
+  - `phx:navigated` only fires for `<.link navigate>` links, but bottom nav uses `<.link href>` (redirect-style)
+  - Now active state correctly updates on every navigation, including browser back/forward
+
 ## [0.4.0] - 2026-04-19
 
 ### Added

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -88,7 +88,7 @@ const FlashAutoDismiss = {
 /**
  * MobileBottomNav hook — keeps the active tab in sync with the current URL.
  * The root layout only renders once per live_session, so @conn.request_path
- * goes stale on live navigation. This hook listens for phx:navigated and
+ * goes stale on live navigation. This hook listens for phx:page-loading-stop and
  * updates the active classes / icons client-side.
  *
  * Expects the <nav> to have data-tabs='[{"path":"/client","icon":"hero-home","activeIcon":"hero-home-solid","label":"Home","fab":false}, ...]'
@@ -98,7 +98,7 @@ const MobileBottomNav = {
     this._updateActive()
     this._applyFabTransform()
     this._unsub = [
-      listen("phx:navigated", () => this._updateActive()),
+      listen("phx:page-loading-stop", () => this._updateActive()),
       listen("popstate", () => this._updateActive()),
     ]
   },

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule GymStudio.MixProject do
   def project do
     [
       app: :gym_studio,
-      version: "0.4.0",
+      version: "0.4.1",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## Problem

The bottom nav active tab indicator doesn't update when clicking nav links in production. The links use `<.link href>` which renders as `data-phx-link="redirect"`, and LiveView only dispatches `phx:navigated` for `<.link navigate>` links — not redirects.

## Fix

Changed `MobileBottomNav` JS hook to listen for `phx:page-loading-stop` instead of `phx:navigated`. This event fires after **every** LiveView navigation completes (both redirects and navigates), so the active tab updates correctly in all cases.

## Changes

- `assets/js/app.js`: Replace `listen("phx:navigated", ...)` with `listen("phx:page-loading-stop", ...)`
- Updated comment to match

## Testing

- All 606 tests pass
- `mix format --check-formatted` ✅
- `mix compile --warnings-as-errors` ✅

Closes #88
