### PR TITLE
feat: convert href to navigate for same-session LiveView links

### DIFF
--- a/lib/gym_studio_web/components/layouts/root.html.heex
+++ b/lib/gym_studio_web/components/layouts/root.html.heex
@@ -133,13 +133,13 @@
                 {@current_scope.user.name || @current_scope.user.email}
               </span>
               <.link
-                href={dashboard_path}
+                navigate={dashboard_path}
                 class="btn btn-ghost btn-sm rounded-full text-gray-700 hover:text-white hover:bg-primary"
               >
                 Dashboard
               </.link>
               <.link
-                href={notifications_path}
+                navigate={notifications_path}
                 class="btn btn-ghost btn-sm btn-circle relative text-gray-700 hover:text-primary"
               >
                 <.icon name="hero-bell" class="size-5" />
@@ -166,7 +166,7 @@
             <%!-- Mobile Nav (simplified — bottom nav handles navigation) --%>
             <div class="flex md:hidden items-center gap-1">
               <.link
-                href={notifications_path}
+                navigate={notifications_path}
                 class="btn btn-ghost btn-sm btn-circle relative text-gray-700"
               >
                 <.icon name="hero-bell" class="size-5" />


### PR DESCRIPTION
## What
Converts `<.link href>` to `<.link navigate>` for links within the same `live_session`, enabling instant LiveView navigation instead of full page reloads.

## Changes
- **Top navbar Dashboard link**: `href` → `navigate` (same live_session: client_portal / trainer_portal / admin_portal)
- **Top navbar Notifications link** (desktop + mobile): `href` → `navigate` (same live_session)
- **Bottom nav**: Already uses `navigate` — no changes needed

## What stays as `href` (cross-session or controller routes)
- Logo → `/` (landing page, different context)
- Settings → `/users/settings` (controller, not LiveView)
- Log out → `/users/log-out` (controller with DELETE method)

## Technical detail
In Phoenix LiveView 1.1.x, `navigate` renders as `data-phx-link="redirect"` which uses pushState + LiveView reconnect over the existing WebSocket — no full page reload. Links without `data-phx-link` (like Settings, Log out) still do full HTTP navigation.

## Testing
- 606 tests passing
- QA verified: navigation between trainer pages works instantly
- Cross-session links (Settings, Log out, Logo) still work correctly
- Bottom nav active state still updates correctly