### PR TITLE
fix: Mobile navbar gap on notched devices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.0] - 2026-04-29
+
+### Changed
+- Landing page release: hide auth routes, trainer section, and portal access (#92, #98, #101)
+  - Auth routes (`/users/register`, `/users/log-in`) redirect to `/`
+  - Trainer section removed from landing page
+  - Client/trainer/admin portals accessible but not linked from landing page
+- All CTA buttons converted to WhatsApp deep links (#93)
+- Phone numbers in locations section link to WhatsApp chat (#97)
+- Facebook icon removed from footer (no Facebook page)
+- Hero CTAs now anchor to `#packages` and `#contact` sections
+- Footer quick links updated: added Packages, removed Trainers
+- 29 auth-related tests excluded with `landing_page_auth` tag
+
+### Fixed
+- Mobile navbar gap on notched devices (iPhone X+) (#99, #101)
+  - Added `viewport-fit=cover` meta tag
+  - Safe area padding via CSS utility classes (`pt-safe-top`, `pb-safe-bottom`, `pb-safe-24`, `pb-safe-20`)
+  - Bottom nav now accounts for `safe-area-inset-bottom` on notched devices
+
 ## [0.4.1] - 2026-04-19
 
 ### Fixed

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -284,3 +284,35 @@
 .flash-auto-dismiss {
   animation: flash-fade-out 5s ease-out forwards;
 }
+
+/* ==========================================================================
+   Safe Area Utilities (notched devices — iPhone X+ etc.)
+   viewport-fit=cover is set in root.html.heex <meta viewport>
+   ========================================================================== */
+
+.pt-safe-top {
+  padding-top: env(safe-area-inset-top);
+}
+
+.pb-safe-bottom {
+  padding-bottom: env(safe-area-inset-bottom);
+}
+
+/* Bottom nav height includes safe-area-inset-bottom so body padding
+   via Tailwind classes (pb-24 / pb-20) correctly clears the bar.
+   DaisyUI's dock component uses the same pattern. */
+
+/* Body padding-bottom that accounts for safe-area-inset-bottom on notched devices */
+.pb-safe-20 {
+  padding-bottom: calc(5rem + env(safe-area-inset-bottom));
+}
+
+.pb-safe-24 {
+  padding-bottom: calc(6rem + env(safe-area-inset-bottom));
+}
+
+@media (min-width: 768px) {
+  .pb-safe-20, .pb-safe-24 {
+    padding-bottom: 0;
+  }
+}

--- a/lib/gym_studio_web/components/layouts.ex
+++ b/lib/gym_studio_web/components/layouts.ex
@@ -41,8 +41,8 @@ defmodule GymStudioWeb.Layouts do
           )
         )
       }
-      class="fixed bottom-0 inset-x-0 z-50 md:hidden"
-      style="backdrop-filter: blur(22px) saturate(180%); -webkit-backdrop-filter: blur(22px) saturate(180%); background: rgba(255, 255, 255, 0.75); padding-bottom: env(safe-area-inset-bottom);"
+      class="fixed bottom-0 inset-x-0 z-50 md:hidden pb-safe-bottom"
+      style="backdrop-filter: blur(22px) saturate(180%); -webkit-backdrop-filter: blur(22px) saturate(180%); background: rgba(255, 255, 255, 0.75);"
     >
       <div class="border-t border-gray-200/50" style="border-top-width: 0.5px;"></div>
       <div class="flex items-center justify-around h-16 px-2 relative">
@@ -108,8 +108,7 @@ defmodule GymStudioWeb.Layouts do
           )
         )
       }
-      class="fixed bottom-0 inset-x-0 z-50 bg-base-100 border-t border-base-300 md:hidden"
-      style="padding-bottom: env(safe-area-inset-bottom);"
+      class="fixed bottom-0 inset-x-0 z-50 bg-base-100 border-t border-base-300 md:hidden pb-safe-bottom"
     >
       <div class="flex items-center justify-around h-18 px-2">
         <%= for tab <- @tabs do %>

--- a/lib/gym_studio_web/components/layouts/root.html.heex
+++ b/lib/gym_studio_web/components/layouts/root.html.heex
@@ -96,13 +96,13 @@
   <body class={[
     "bg-base-100",
     @current_scope &&
-      if(@current_scope.user.role == :client, do: "pb-24 md:pb-0", else: "pb-20 md:pb-0")
+      if(@current_scope.user.role == :client,
+        do: "pb-safe-24 md:pb-0",
+        else: "pb-safe-20 md:pb-0"
+      )
   ]}>
     <%!-- Modern Navigation Header --%>
-    <header
-      class="sticky top-0 z-50 bg-white/95 backdrop-blur-sm border-b border-base-300/50 shadow-sm"
-      style="padding-top: env(safe-area-inset-top);"
-    >
+    <header class="sticky top-0 z-50 bg-white/95 backdrop-blur-sm border-b border-base-300/50 shadow-sm pt-safe-top">
       <nav class="container mx-auto px-4 sm:px-6 lg:px-8">
         <div class="flex items-center justify-between h-16 sm:h-20">
           <%!-- Logo --%>

--- a/lib/gym_studio_web/components/layouts/root.html.heex
+++ b/lib/gym_studio_web/components/layouts/root.html.heex
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
     <meta name="csrf-token" content={get_csrf_token()} />
     <meta
       name="description"
@@ -99,7 +99,10 @@
       if(@current_scope.user.role == :client, do: "pb-24 md:pb-0", else: "pb-20 md:pb-0")
   ]}>
     <%!-- Modern Navigation Header --%>
-    <header class="sticky top-0 z-50 bg-white/95 backdrop-blur-sm border-b border-base-300/50 shadow-sm">
+    <header
+      class="sticky top-0 z-50 bg-white/95 backdrop-blur-sm border-b border-base-300/50 shadow-sm"
+      style="padding-top: env(safe-area-inset-top);"
+    >
       <nav class="container mx-auto px-4 sm:px-6 lg:px-8">
         <div class="flex items-center justify-between h-16 sm:h-20">
           <%!-- Logo --%>

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule GymStudio.MixProject do
   def project do
     [
       app: :gym_studio,
-      version: "0.4.1",
+      version: "0.5.0",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/gym_studio_web/components/layouts_test.exs
+++ b/test/gym_studio_web/components/layouts_test.exs
@@ -189,7 +189,7 @@ defmodule GymStudioWeb.LayoutsTest do
           current_path: "/client"
         )
 
-      assert html =~ "safe-area-inset-bottom"
+      assert html =~ "pb-safe-bottom"
     end
 
     test "nav landmark element is present" do
@@ -291,8 +291,8 @@ defmodule GymStudioWeb.LayoutsTest do
       # Items should be centered vertically, not bottom-aligned
       assert html =~ "items-center"
       refute html =~ "items-end"
-      # Safe area padding via style attribute
-      assert html =~ "safe-area-inset-bottom"
+      # Safe area padding via CSS utility class
+      assert html =~ "pb-safe-bottom"
     end
   end
 end


### PR DESCRIPTION
## Problem
On mobile devices (especially with notches), the sticky navbar has a visible gap above it because the viewport doesn't extend into the safe area.

## Changes
- Added viewport-fit=cover to the viewport meta tag
- Added env(safe-area-inset-top) padding to the sticky header

## Testing
- mix format --check-formatted
- mix compile --warnings-as-errors
- 603 tests, 0 failures, 29 excluded

Closes #99