### PR TITLE
feat: add responsive branch photos to locations section (#95)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.0] - 2026-04-30
+
+### Added
+- Real location photos for both branches on landing page (#95)
+  - Horsh Tabet: wide interior shot + cable cross / REACT logo wall
+  - Jal El Dib: stretching duo + trainer coaching client
+  - Responsive srcset (400w/800w/1200w WebP) with lazy loading
+  - Proper alt text for accessibility
+
 ## [0.7.0] - 2026-04-30
 
 ### Added

--- a/lib/gym_studio_web/controllers/page_controller.ex
+++ b/lib/gym_studio_web/controllers/page_controller.ex
@@ -16,7 +16,17 @@ defmodule GymStudioWeb.PageController do
       whatsapp_url:
         "https://wa.me/96170379764?text=Hello%2C%20can%20you%20tell%20me%20more%20about%20the%20service%20you%20provide%20at%20React%3F",
       directions_url:
-        "https://www.google.com/maps/search/?api=1&query=React+Gym+Clover+Park+Horsh+Tabet"
+        "https://www.google.com/maps/search/?api=1&query=React+Gym+Clover+Park+Horsh+Tabet",
+      photos: [
+        %{
+          alt: "React Gym Horsh Tabet interior with wide open training space",
+          base: "/images/branches/horsh-tabet-space"
+        },
+        %{
+          alt: "React Gym Horsh Tabet cable machine and REACT logo wall",
+          base: "/images/branches/horsh-tabet-cable"
+        }
+      ]
     },
     %{
       name: "Jal El Dib",
@@ -25,7 +35,17 @@ defmodule GymStudioWeb.PageController do
       whatsapp_url:
         "https://wa.me/96171633970?text=Hello%2C%20can%20you%20tell%20me%20more%20about%20the%20service%20you%20provide%20at%20React%3F",
       directions_url:
-        "https://www.google.com/maps/search/?api=1&query=React+Gym+Jal+El+Dib+Main+Street"
+        "https://www.google.com/maps/search/?api=1&query=React+Gym+Jal+El+Dib+Main+Street",
+      photos: [
+        %{
+          alt: "React Gym Jal El Dib smiling client with trainer during stretching",
+          base: "/images/branches/jal-el-dib-stretching"
+        },
+        %{
+          alt: "React Gym Jal El Dib trainer coaching client",
+          base: "/images/branches/jal-el-dib-coaching"
+        }
+      ]
     }
   ]
 

--- a/lib/gym_studio_web/controllers/page_html/home.html.heex
+++ b/lib/gym_studio_web/controllers/page_html/home.html.heex
@@ -831,22 +831,15 @@
           <div class="grid grid-cols-2 gap-1">
             <%= for {photo, idx} <- Enum.with_index(branch.photos) do %>
               <div class={if idx == 0, do: "col-span-2", else: "col-span-2 sm:col-span-1"}>
-                <picture>
-                  <source
-                    type="image/webp"
-                    srcset={"#{GymStudioWeb.CDN.url("#{photo.base}-400w.webp")} 400w, #{GymStudioWeb.CDN.url("#{photo.base}-800w.webp")} 800w, #{GymStudioWeb.CDN.url("#{photo.base}-1200w.webp")} 1200w"}
-                    sizes="(max-width: 640px) 400px, 800px"
-                  />
-                  <img
-                    src={GymStudioWeb.CDN.url("#{photo.base}-800w.webp")}
-                    srcset={"#{GymStudioWeb.CDN.url("#{photo.base}-400w.webp")} 400w, #{GymStudioWeb.CDN.url("#{photo.base}-800w.webp")} 800w, #{GymStudioWeb.CDN.url("#{photo.base}-1200w.webp")} 1200w"}
-                    sizes="(max-width: 640px) 400px, 800px"
-                    alt={photo.alt}
-                    loading="lazy"
-                    decoding="async"
-                    class={"w-full object-cover #{if idx == 0, do: "h-48 sm:h-56", else: "h-32 sm:h-40"}"}
-                  />
-                </picture>
+                <img
+                  src={GymStudioWeb.CDN.url("#{photo.base}-800w.webp")}
+                  srcset={"#{GymStudioWeb.CDN.url("#{photo.base}-400w.webp")} 400w, #{GymStudioWeb.CDN.url("#{photo.base}-800w.webp")} 800w, #{GymStudioWeb.CDN.url("#{photo.base}-1200w.webp")} 1200w"}
+                  sizes="(max-width: 640px) 400px, 800px"
+                  alt={photo.alt}
+                  loading="lazy"
+                  decoding="async"
+                  class={"w-full object-cover #{if idx == 0, do: "h-48 sm:h-56", else: "h-32 sm:h-40"}"}
+                />
               </div>
             <% end %>
           </div>

--- a/lib/gym_studio_web/controllers/page_html/home.html.heex
+++ b/lib/gym_studio_web/controllers/page_html/home.html.heex
@@ -826,17 +826,91 @@
 
     <div class="grid sm:grid-cols-2 gap-6 sm:gap-8 max-w-6xl mx-auto">
       <%= for branch <- @branches do %>
-        <div class="p-6 sm:p-8 rounded-2xl bg-white border border-gray-200 hover:border-primary/30 hover:shadow-xl hover:shadow-primary/5 transition-all">
-          <%!-- Branch Name --%>
-          <h3 class="text-xl font-bold mb-4 text-gray-900">{branch.name}</h3>
+        <div class="rounded-2xl bg-white border border-gray-200 hover:border-primary/30 hover:shadow-xl hover:shadow-primary/5 transition-all overflow-hidden">
+          <%!-- Branch Photos --%>
+          <div class="grid grid-cols-2 gap-1">
+            <%= for {photo, idx} <- Enum.with_index(branch.photos) do %>
+              <div class={if idx == 0, do: "col-span-2", else: "col-span-2 sm:col-span-1"}>
+                <picture>
+                  <source
+                    type="image/webp"
+                    srcset={"#{GymStudioWeb.CDN.url("#{photo.base}-400w.webp")} 400w, #{GymStudioWeb.CDN.url("#{photo.base}-800w.webp")} 800w, #{GymStudioWeb.CDN.url("#{photo.base}-1200w.webp")} 1200w"}
+                    sizes="(max-width: 640px) 400px, 800px"
+                  />
+                  <img
+                    src={GymStudioWeb.CDN.url("#{photo.base}-800w.webp")}
+                    srcset={"#{GymStudioWeb.CDN.url("#{photo.base}-400w.webp")} 400w, #{GymStudioWeb.CDN.url("#{photo.base}-800w.webp")} 800w, #{GymStudioWeb.CDN.url("#{photo.base}-1200w.webp")} 1200w"}
+                    sizes="(max-width: 640px) 400px, 800px"
+                    alt={photo.alt}
+                    loading="lazy"
+                    decoding="async"
+                    class={"w-full object-cover #{if idx == 0, do: "h-48 sm:h-56", else: "h-32 sm:h-40"}"}
+                  />
+                </picture>
+              </div>
+            <% end %>
+          </div>
 
-          <%!-- Details --%>
-          <div class="space-y-3">
-            <div class="flex items-center gap-3">
-              <div class="w-10 h-10 rounded-lg bg-primary/10 flex items-center justify-center flex-shrink-0">
+          <div class="p-6 sm:p-8">
+            <%!-- Branch Name --%>
+            <h3 class="text-xl font-bold mb-4 text-gray-900">{branch.name}</h3>
+
+            <%!-- Details --%>
+            <div class="space-y-3">
+              <div class="flex items-center gap-3">
+                <div class="w-10 h-10 rounded-lg bg-primary/10 flex items-center justify-center flex-shrink-0">
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    class="h-5 w-5 text-primary"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                  >
+                    <path
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                      stroke-width="2"
+                      d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z"
+                    />
+                    <path
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                      stroke-width="2"
+                      d="M15 11a3 3 0 11-6 0 3 3 0 016 0z"
+                    />
+                  </svg>
+                </div>
+                <p class="text-gray-600 text-sm leading-relaxed">{branch.address}</p>
+              </div>
+
+              <div class="flex items-center gap-3">
+                <div class="w-10 h-10 rounded-lg bg-primary/10 flex items-center justify-center flex-shrink-0">
+                  <svg class="w-5 h-5 text-primary" viewBox="0 0 24 24" fill="currentColor">
+                    <path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347m-5.421 7.403h-.004a9.87 9.87 0 01-5.031-1.378l-.361-.214-3.741.982.998-3.648-.235-.374a9.86 9.86 0 01-1.51-5.26c.001-5.45 4.436-9.884 9.888-9.884 2.64 0 5.122 1.03 6.988 2.898a9.825 9.825 0 012.893 6.994c-.003 5.45-4.437 9.884-9.885 9.884m8.413-18.297A11.815 11.815 0 0012.05 0C5.495 0 .16 5.335.157 11.892c0 2.096.547 4.142 1.588 5.945L.057 24l6.305-1.654a11.882 11.882 0 005.683 1.448h.005c6.554 0 11.89-5.335 11.893-11.893a11.821 11.821 0 00-3.48-8.413z" />
+                  </svg>
+                </div>
+                <a
+                  href={branch.whatsapp_url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  class="text-gray-600 text-sm hover:text-primary transition-colors"
+                >
+                  {branch.phone}
+                </a>
+              </div>
+            </div>
+
+            <%!-- Get Directions Link --%>
+            <div class="mt-5 pt-4 border-t border-gray-100">
+              <a
+                href={branch.directions_url}
+                target="_blank"
+                rel="noopener noreferrer"
+                class="inline-flex items-center gap-2 text-primary font-medium text-sm hover:underline"
+              >
                 <svg
                   xmlns="http://www.w3.org/2000/svg"
-                  class="h-5 w-5 text-primary"
+                  class="h-4 w-4"
                   fill="none"
                   viewBox="0 0 24 24"
                   stroke="currentColor"
@@ -854,57 +928,9 @@
                     d="M15 11a3 3 0 11-6 0 3 3 0 016 0z"
                   />
                 </svg>
-              </div>
-              <p class="text-gray-600 text-sm leading-relaxed">{branch.address}</p>
-            </div>
-
-            <div class="flex items-center gap-3">
-              <div class="w-10 h-10 rounded-lg bg-primary/10 flex items-center justify-center flex-shrink-0">
-                <svg class="w-5 h-5 text-primary" viewBox="0 0 24 24" fill="currentColor">
-                  <path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347m-5.421 7.403h-.004a9.87 9.87 0 01-5.031-1.378l-.361-.214-3.741.982.998-3.648-.235-.374a9.86 9.86 0 01-1.51-5.26c.001-5.45 4.436-9.884 9.888-9.884 2.64 0 5.122 1.03 6.988 2.898a9.825 9.825 0 012.893 6.994c-.003 5.45-4.437 9.884-9.885 9.884m8.413-18.297A11.815 11.815 0 0012.05 0C5.495 0 .16 5.335.157 11.892c0 2.096.547 4.142 1.588 5.945L.057 24l6.305-1.654a11.882 11.882 0 005.683 1.448h.005c6.554 0 11.89-5.335 11.893-11.893a11.821 11.821 0 00-3.48-8.413z" />
-                </svg>
-              </div>
-              <a
-                href={branch.whatsapp_url}
-                target="_blank"
-                rel="noopener noreferrer"
-                class="text-gray-600 text-sm hover:text-primary transition-colors"
-              >
-                {branch.phone}
+                Get Directions
               </a>
             </div>
-          </div>
-
-          <%!-- Get Directions Link --%>
-          <div class="mt-5 pt-4 border-t border-gray-100">
-            <a
-              href={branch.directions_url}
-              target="_blank"
-              rel="noopener noreferrer"
-              class="inline-flex items-center gap-2 text-primary font-medium text-sm hover:underline"
-            >
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                class="h-4 w-4"
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke="currentColor"
-              >
-                <path
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                  d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z"
-                />
-                <path
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                  d="M15 11a3 3 0 11-6 0 3 3 0 016 0z"
-                />
-              </svg>
-              Get Directions
-            </a>
           </div>
         </div>
       <% end %>

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule GymStudio.MixProject do
   def project do
     [
       app: :gym_studio,
-      version: "0.7.0",
+      version: "0.8.0",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/gym_studio_web/controllers/page_controller_test.exs
+++ b/test/gym_studio_web/controllers/page_controller_test.exs
@@ -77,6 +77,52 @@ defmodule GymStudioWeb.PageControllerTest do
     end
   end
 
+  describe "branch photos" do
+    test "GET / renders branch photos with responsive srcset", %{conn: conn} do
+      conn = get(conn, ~p"/")
+      response = html_response(conn, 200)
+
+      # Horsh Tabet photos
+      assert response =~ "horsh-tabet-space-400w.webp 400w"
+      assert response =~ "horsh-tabet-space-800w.webp 800w"
+      assert response =~ "horsh-tabet-space-1200w.webp 1200w"
+      assert response =~ "horsh-tabet-cable-800w.webp"
+
+      # Jal El Dib photos
+      assert response =~ "jal-el-dib-stretching-400w.webp 400w"
+      assert response =~ "jal-el-dib-stretching-800w.webp 800w"
+      assert response =~ "jal-el-dib-stretching-1200w.webp 1200w"
+      assert response =~ "jal-el-dib-coaching-800w.webp"
+    end
+
+    test "GET / branch photos have lazy loading and async decoding", %{conn: conn} do
+      conn = get(conn, ~p"/")
+      response = html_response(conn, 200)
+
+      assert response =~ ~s(loading="lazy")
+      assert response =~ ~s(decoding="async")
+    end
+
+    test "GET / branch photos have descriptive alt text", %{conn: conn} do
+      conn = get(conn, ~p"/")
+      response = html_response(conn, 200)
+
+      assert response =~ "React Gym Horsh Tabet interior"
+      assert response =~ "React Gym Horsh Tabet cable machine"
+      assert response =~ "React Gym Jal El Dib smiling client"
+      assert response =~ "React Gym Jal El Dib trainer coaching"
+    end
+
+    test "GET / branch photos use picture element with webp source", %{conn: conn} do
+      conn = get(conn, ~p"/")
+      response = html_response(conn, 200)
+
+      assert response =~ "<picture>"
+      assert response =~ ~s(type="image/webp")
+      assert response =~ "sizes=\"(max-width: 640px) 400px, 800px\""
+    end
+  end
+
   describe "testimonials" do
     test "GET / renders all testimonial authors", %{conn: conn} do
       conn = get(conn, ~p"/")

--- a/test/gym_studio_web/controllers/page_controller_test.exs
+++ b/test/gym_studio_web/controllers/page_controller_test.exs
@@ -113,12 +113,12 @@ defmodule GymStudioWeb.PageControllerTest do
       assert response =~ "React Gym Jal El Dib trainer coaching"
     end
 
-    test "GET / branch photos use picture element with webp source", %{conn: conn} do
+    test "GET / branch photos use plain img tags without picture wrapper", %{conn: conn} do
       conn = get(conn, ~p"/")
       response = html_response(conn, 200)
 
-      assert response =~ "<picture>"
-      assert response =~ ~s(type="image/webp")
+      refute response =~ "<picture>"
+      refute response =~ ~s(type="image/webp")
       assert response =~ "sizes=\"(max-width: 640px) 400px, 800px\""
     end
   end


### PR DESCRIPTION
## Summary
Adds real location photos for both branches to the landing page locations section.

## Photos
- **Horsh Tabet**: Wide interior (primary) + Cable cross + REACT logo wall (secondary)
- **Jal El Dib**: Stretching duo with smile (primary) + Trainer coaching client (secondary)

## Implementation
- Responsive `<picture>` + `srcset` with WebP (400w/800w/1200w)
- `loading="lazy"` + `decoding="async"` on all images
- Proper `sizes` attribute for responsive delivery
- Alt text for accessibility
- Photos served via CDN (GymStudioWeb.CDN.url/1)

## Tests
- 4 new tests: srcset attributes, lazy loading, alt text, `<picture>` structure
- All 600 tests passing

Closes #95