### PR TITLE
fix: Standard card — Flexible scheduling instead of Priority booking

### DIFF
--- a/lib/gym_studio_web/controllers/page_html/home.html.heex
+++ b/lib/gym_studio_web/controllers/page_html/home.html.heex
@@ -583,7 +583,7 @@
                 clip-rule="evenodd"
               />
             </svg>
-            <span>Priority booking</span>
+            <span>Flexible scheduling</span>
           </li>
         </ul>
         <button


### PR DESCRIPTION
Zaher requested: remove Priority booking from Standard card, replace with Flexible scheduling.