### PR TITLE
fix: remove em dashes, natural punctuation (v0.8.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.1] - 2026-05-01
+
+### Changed
+- Replace em dashes with more natural punctuation on landing page (#109)
+  - Hero: period split instead of dash
+  - 100% Personal section: comma flow instead of dash
+  - Ready to Start section: colon instead of dash
+- Standard package card: "Flexible scheduling" instead of "Priority booking" (#109)
+
 ## [0.8.0] - 2026-04-30
 
 ### Added

--- a/lib/gym_studio_web/controllers/page_html/home.html.heex
+++ b/lib/gym_studio_web/controllers/page_html/home.html.heex
@@ -90,7 +90,7 @@
 
       <p class="text-base sm:text-lg text-white/70 max-w-2xl mx-auto mb-8 leading-relaxed">
         One-on-one training sessions in a private, welcoming studio.
-        No crowds, no distractions — just you, your trainer, and your goals.
+        No crowds, no distractions. Just you, your trainer, and your goals.
       </p>
 
       <%!-- CTA Buttons — open WhatsApp branch selector modal --%>
@@ -196,7 +196,7 @@
         </div>
         <h3 class="text-xl font-bold mb-3 text-gray-900">100% Personal Attention</h3>
         <p class="text-gray-600 leading-relaxed">
-          Every session is one-on-one. Your trainer focuses entirely on you — your form, your progress, your goals.
+          Every session is one-on-one. Your trainer focuses entirely on you, your form, your progress, your goals.
         </p>
       </div>
 
@@ -996,7 +996,7 @@
       Ready to Start?
     </h2>
     <p class="text-lg sm:text-xl text-white/80 mb-8 max-w-2xl mx-auto leading-relaxed">
-      Join our community and experience fitness the way it should be — personal, welcoming, and effective.
+      Join our community and experience fitness the way it should be: personal, welcoming, and effective.
     </p>
     <button
       onclick="document.getElementById('whatsapp-modal').showModal()"

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule GymStudio.MixProject do
   def project do
     [
       app: :gym_studio,
-      version: "0.8.0",
+      version: "0.8.1",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
Replaces em dashes with more natural, human-sounding punctuation throughout landing page copy.

Changes:
- Hero: period split instead of dash
- 100% Personal: comma flow instead of dash  
- Ready to Start: colon instead of dash
- Also includes: Standard card → Flexible scheduling

Bumps version to 0.8.1