### PR TITLE
fix: 1 photo per branch + prevent auto-scroll to packages (v0.8.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.3] - 2026-05-01
+
+### Changed
+- Reduce to 1 photo per branch (Horsh Tabet: kettlebell press, Jal El Dib: stretching)
+- Fix mobile auto-scroll to packages section — use scrollLeft instead of scrollIntoView
+
 ## [0.8.2] - 2026-05-01
 
 ### Changed

--- a/lib/gym_studio_web/controllers/page_controller.ex
+++ b/lib/gym_studio_web/controllers/page_controller.ex
@@ -21,10 +21,6 @@ defmodule GymStudioWeb.PageController do
         %{
           alt: "React Gym Horsh Tabet member performing kettlebell press",
           base: "/images/branches/horsh-tabet-kettlebell"
-        },
-        %{
-          alt: "React Gym Horsh Tabet strength training with trap bar",
-          base: "/images/branches/horsh-tabet-row"
         }
       ]
     },
@@ -40,10 +36,6 @@ defmodule GymStudioWeb.PageController do
         %{
           alt: "React Gym Jal El Dib smiling client with trainer during stretching",
           base: "/images/branches/jal-el-dib-stretching"
-        },
-        %{
-          alt: "React Gym Jal El Dib trainer coaching client",
-          base: "/images/branches/jal-el-dib-coaching"
         }
       ]
     }

--- a/lib/gym_studio_web/controllers/page_html/home.html.heex
+++ b/lib/gym_studio_web/controllers/page_html/home.html.heex
@@ -703,10 +703,13 @@
     var rafPending = false;
 
     // Scroll to Standard (center card) on load for mobile
+    // Use scrollLeft instead of scrollIntoView to avoid vertical page scroll on mobile browsers
     var standardCard = document.getElementById("package-standard");
     if (standardCard && window.innerWidth < 1024) {
       window.addEventListener("load", function() {
-        standardCard.scrollIntoView({ inline: "center", block: "nearest", behavior: "instant" });
+        var cardLeft = standardCard.offsetLeft - carousel.offsetLeft;
+        var offset = cardLeft - (carousel.offsetWidth / 2) + (standardCard.offsetWidth / 2);
+        carousel.scrollLeft = offset;
       });
     }
 
@@ -764,11 +767,15 @@
 
     carousel.addEventListener("scroll", onScroll, { passive: true });
 
-    // Dot click scrolls to card
+    // Dot click scrolls to card (horizontal only, no vertical page scroll)
     dots.forEach(function(dot, i) {
       dot.addEventListener("click", function() {
         var card = carousel.children[i];
-        if (card) card.scrollIntoView({ inline: "center", block: "nearest", behavior: "smooth" });
+        if (card) {
+          var cardLeft = card.offsetLeft - carousel.offsetLeft;
+          var offset = cardLeft - (carousel.offsetWidth / 2) + (card.offsetWidth / 2);
+          carousel.scrollTo({ left: offset, behavior: "smooth" });
+        }
       });
     });
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule GymStudio.MixProject do
   def project do
     [
       app: :gym_studio,
-      version: "0.8.2",
+      version: "0.8.3",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/gym_studio_web/controllers/page_controller_test.exs
+++ b/test/gym_studio_web/controllers/page_controller_test.exs
@@ -82,17 +82,15 @@ defmodule GymStudioWeb.PageControllerTest do
       conn = get(conn, ~p"/")
       response = html_response(conn, 200)
 
-      # Horsh Tabet photos
-      assert response =~ "horsh-tabet-space-400w.webp 400w"
-      assert response =~ "horsh-tabet-space-800w.webp 800w"
-      assert response =~ "horsh-tabet-space-1200w.webp 1200w"
-      assert response =~ "horsh-tabet-cable-800w.webp"
+      # Horsh Tabet photo
+      assert response =~ "horsh-tabet-kettlebell-400w.webp 400w"
+      assert response =~ "horsh-tabet-kettlebell-800w.webp 800w"
+      assert response =~ "horsh-tabet-kettlebell-1200w.webp 1200w"
 
-      # Jal El Dib photos
+      # Jal El Dib photo
       assert response =~ "jal-el-dib-stretching-400w.webp 400w"
       assert response =~ "jal-el-dib-stretching-800w.webp 800w"
       assert response =~ "jal-el-dib-stretching-1200w.webp 1200w"
-      assert response =~ "jal-el-dib-coaching-800w.webp"
     end
 
     test "GET / branch photos have lazy loading and async decoding", %{conn: conn} do
@@ -107,10 +105,8 @@ defmodule GymStudioWeb.PageControllerTest do
       conn = get(conn, ~p"/")
       response = html_response(conn, 200)
 
-      assert response =~ "React Gym Horsh Tabet interior"
-      assert response =~ "React Gym Horsh Tabet cable machine"
+      assert response =~ "React Gym Horsh Tabet member performing kettlebell press"
       assert response =~ "React Gym Jal El Dib smiling client"
-      assert response =~ "React Gym Jal El Dib trainer coaching"
     end
 
     test "GET / branch photos use plain img tags without picture wrapper", %{conn: conn} do


### PR DESCRIPTION
### Changes
- **Photos**: Reduce to 1 photo per branch (Horsh Tabet: kettlebell press, Jal El Dib: stretching)
- **Auto-scroll fix**: Replace `scrollIntoView` with `scrollLeft` to prevent mobile browsers from scrolling the page to the packages section on load
- Updated tests for new photo references

### Why
Zaher requested: (1) only one photo per branch, (2) site should open at the top/hero, not jump to packages.