### PR TITLE
fix: Explore Our Packages → scroll to packages

### DIFF
--- a/lib/gym_studio_web/controllers/page_html/home.html.heex
+++ b/lib/gym_studio_web/controllers/page_html/home.html.heex
@@ -113,12 +113,12 @@
             />
           </svg>
         </button>
-        <button
-          onclick="document.getElementById('whatsapp-modal').showModal()"
+        <a
+          href="#packages"
           class="btn btn-outline btn-lg text-base sm:text-lg rounded-full border-white/30 text-white hover:bg-white/10 hover:border-white/50"
         >
           Explore Our Packages
-        </button>
+        </a>
       </div>
 
       <%!-- Social Proof Stats --%>


### PR DESCRIPTION
Change the hero 'Explore Our Packages' button from WhatsApp modal to anchor link `#packages` so it scrolls down to the pricing cards.