### PR TITLE
fix: footer locations → scroll to locations section

### DIFF
--- a/lib/gym_studio_web/controllers/page_html/home.html.heex
+++ b/lib/gym_studio_web/controllers/page_html/home.html.heex
@@ -1083,9 +1083,7 @@
           <%= for branch <- @branches do %>
             <li>
               <a
-                href={branch.whatsapp_url}
-                target="_blank"
-                rel="noopener noreferrer"
+                href="#locations"
                 class="hover:text-primary transition-colors"
               >
                 {branch.name}


### PR DESCRIPTION
Footer branch names now link to #locations anchor instead of WhatsApp.