### PR TITLE
fix: correct Get Directions — use GPS coordinates

### DIFF
--- a/lib/gym_studio_web/controllers/page_controller.ex
+++ b/lib/gym_studio_web/controllers/page_controller.ex
@@ -16,7 +16,7 @@ defmodule GymStudioWeb.PageController do
       whatsapp_url:
         "https://wa.me/96170379764?text=Hello%2C%20can%20you%20tell%20me%20more%20about%20the%20service%20you%20provide%20at%20React%3F",
       directions_url:
-        "https://www.google.com/maps/search/?api=1&query=React+Gym+Clover+Park+Horsh+Tabet",
+        "https://www.google.com/maps/search/?api=1&query=33.8709%2C35.5343",
       photos: [
         %{
           alt: "React Gym Horsh Tabet member performing kettlebell press",
@@ -31,7 +31,7 @@ defmodule GymStudioWeb.PageController do
       whatsapp_url:
         "https://wa.me/96171633970?text=Hello%2C%20can%20you%20tell%20me%20more%20about%20the%20service%20you%20provide%20at%20React%3F",
       directions_url:
-        "https://www.google.com/maps/search/?api=1&query=React+Gym+Jal+El+Dib+Main+Street",
+        "https://www.google.com/maps/search/?api=1&query=33.9069%2C35.5801",
       photos: [
         %{
           alt: "React Gym Jal El Dib smiling client with trainer during stretching",

--- a/test/gym_studio_web/controllers/page_controller_test.exs
+++ b/test/gym_studio_web/controllers/page_controller_test.exs
@@ -51,8 +51,8 @@ defmodule GymStudioWeb.PageControllerTest do
       response = html_response(conn, 200)
 
       assert response =~ "Get Directions"
-      assert response =~ "React+Gym+Clover+Park+Horsh+Tabet"
-      assert response =~ "React+Gym+Jal+El+Dib+Main+Street"
+      assert response =~ "query=33.8709"
+      assert response =~ "query=33.9069"
     end
 
     test "GET / does not display operating hours", %{conn: conn} do


### PR DESCRIPTION
Google Maps text search was resolving Horsh Tabet directions to Jal El Dib. Switched to GPS coordinates from the production database.