### PR TITLE
fix: correct Horsh Tabet GPS coordinates

### DIFF
--- a/lib/gym_studio_web/controllers/page_controller.ex
+++ b/lib/gym_studio_web/controllers/page_controller.ex
@@ -16,7 +16,7 @@ defmodule GymStudioWeb.PageController do
       whatsapp_url:
         "https://wa.me/96170379764?text=Hello%2C%20can%20you%20tell%20me%20more%20about%20the%20service%20you%20provide%20at%20React%3F",
       directions_url:
-        "https://www.google.com/maps/search/?api=1&query=33.8709%2C35.5343",
+        "https://www.google.com/maps/search/?api=1&query=33.8953%2C35.5106",
       photos: [
         %{
           alt: "React Gym Horsh Tabet member performing kettlebell press",

--- a/test/gym_studio_web/controllers/page_controller_test.exs
+++ b/test/gym_studio_web/controllers/page_controller_test.exs
@@ -51,7 +51,7 @@ defmodule GymStudioWeb.PageControllerTest do
       response = html_response(conn, 200)
 
       assert response =~ "Get Directions"
-      assert response =~ "query=33.8709"
+      assert response =~ "query=33.8953"
       assert response =~ "query=33.9069"
     end
 


### PR DESCRIPTION
Updated Horsh Tabet coordinates to match the actual Google Maps listing: 33.8953, 35.5106