### PR TITLE
fix: use /place/ URL for exact location pin

### DIFF
--- a/lib/gym_studio_web/controllers/page_controller.ex
+++ b/lib/gym_studio_web/controllers/page_controller.ex
@@ -16,7 +16,7 @@ defmodule GymStudioWeb.PageController do
       whatsapp_url:
         "https://wa.me/96170379764?text=Hello%2C%20can%20you%20tell%20me%20more%20about%20the%20service%20you%20provide%20at%20React%3F",
       directions_url:
-        "https://www.google.com/maps/search/?api=1&query=33.8953%2C35.5106",
+        "https://www.google.com/maps/place/33.895287,35.5105958",
       photos: [
         %{
           alt: "React Gym Horsh Tabet member performing kettlebell press",
@@ -31,7 +31,7 @@ defmodule GymStudioWeb.PageController do
       whatsapp_url:
         "https://wa.me/96171633970?text=Hello%2C%20can%20you%20tell%20me%20more%20about%20the%20service%20you%20provide%20at%20React%3F",
       directions_url:
-        "https://www.google.com/maps/search/?api=1&query=33.9069%2C35.5801",
+        "https://www.google.com/maps/place/33.9069,35.5801",
       photos: [
         %{
           alt: "React Gym Jal El Dib smiling client with trainer during stretching",

--- a/test/gym_studio_web/controllers/page_controller_test.exs
+++ b/test/gym_studio_web/controllers/page_controller_test.exs
@@ -51,8 +51,8 @@ defmodule GymStudioWeb.PageControllerTest do
       response = html_response(conn, 200)
 
       assert response =~ "Get Directions"
-      assert response =~ "query=33.8953"
-      assert response =~ "query=33.9069"
+      assert response =~ "place/33.895"
+      assert response =~ "place/33.9069"
     end
 
     test "GET / does not display operating hours", %{conn: conn} do


### PR DESCRIPTION
Switched from `/search/?api=1&query=` to `/place/` format. The search API was picking nearby businesses instead of the exact gym location.