### PR TITLE
fix: remove redundant one-on-one text

### DIFF
--- a/lib/gym_studio_web/controllers/page_html/home.html.heex
+++ b/lib/gym_studio_web/controllers/page_html/home.html.heex
@@ -196,7 +196,7 @@
         </div>
         <h3 class="text-xl font-bold mb-3 text-gray-900">100% Personal Attention</h3>
         <p class="text-gray-600 leading-relaxed">
-          Every session is one-on-one. Your trainer focuses entirely on you, your form, your progress, your goals.
+          Your trainer focuses entirely on you, your form, your progress, your goals.
         </p>
       </div>
 


### PR DESCRIPTION
Removed 'Every session is one-on-one.' from the 100% Personal Attention feature — it's already implied.