### PR TITLE
Configure custom domain reactgym.com + keep app always running

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -12,16 +12,16 @@ primary_region = 'cdg'
   release_command = '/app/bin/migrate'
 
 [env]
-  PHX_HOST = 'gym-studio.fly.dev'
+  PHX_HOST = 'reactgym.com'
   PORT = '8080'
   ECTO_IPV6 = 'true'
 
 [http_service]
   internal_port = 8080
   force_https = true
-  auto_stop_machines = 'stop'
+  auto_stop_machines = false
   auto_start_machines = true
-  min_machines_running = 0
+  min_machines_running = 1
   processes = ['app']
 
   [http_service.concurrency]


### PR DESCRIPTION
## Changes
- `PHX_HOST`: `gym-studio.fly.dev` → `reactgym.com`
- `auto_stop_machines`: `'stop'` → `false` (app no longer sleeps when idle)
- `min_machines_running`: `0` → `1` (always at least 1 machine running)

## Why
- Custom domain purchased (reactgym.com via Cloudflare)
- Production website needs to be always available — no cold starts
- DNS records still need to be added on Cloudflare side

## Note
Changes already deployed to Fly.io (deployed from this branch). This PR formalizes the config in the repo.