### PR TITLE
feat: Add opening hours and website link (#125)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.5] - 2026-05-02
+
+### Added
+- Opening hours section on landing page (Mon–Fri 6 AM–10 PM, Sat 6 AM–2 PM, Sun Closed)
+- "Visit Our Website" link on `/links` page (points to reactgym.com)
+
+### Changed
+- Opening hours copy: "Both" → "All branches"
+- Removed bottom note from opening hours section
+
 ## [0.8.4] - 2026-05-02
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Opening hours section on landing page (Mon–Fri 6 AM–10 PM, Sat 6 AM–2 PM, Sun Closed)
-- "Visit Our Website" link on `/links` page (points to reactgym.com)
+- "Visit Our Website" link on `/links` page (links to site root)
 
 ### Changed
 - Opening hours copy: "Both" → "All branches"

--- a/lib/gym_studio_web/controllers/page_html/home.html.heex
+++ b/lib/gym_studio_web/controllers/page_html/home.html.heex
@@ -1006,7 +1006,7 @@
         When We're <span class="text-primary">Open</span>
       </h2>
       <p class="text-base sm:text-lg text-gray-600 max-w-xl mx-auto">
-        Both branches follow the same schedule
+        All branches follow the same schedule
       </p>
     </div>
 
@@ -1027,24 +1027,6 @@
           </div>
         </div>
       </div>
-
-      <p class="text-center text-sm text-gray-500 mt-5">
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          class="h-4 w-4 inline-block mr-1 -mt-0.5 text-primary"
-          fill="none"
-          viewBox="0 0 24 24"
-          stroke="currentColor"
-        >
-          <path
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            stroke-width="2"
-            d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"
-          />
-        </svg>
-        Both Horsh Tabet &amp; Jal El Dib branches
-      </p>
     </div>
   </div>
 </section>

--- a/lib/gym_studio_web/controllers/page_html/home.html.heex
+++ b/lib/gym_studio_web/controllers/page_html/home.html.heex
@@ -995,6 +995,60 @@
   </div>
 </section>
 
+<%!-- Opening Hours Section --%>
+<section id="hours" class="py-16 sm:py-20 bg-white">
+  <div class="container mx-auto px-4">
+    <div class="text-center mb-10 sm:mb-14">
+      <span class="inline-block text-primary font-semibold text-sm uppercase tracking-wider mb-3">
+        Opening Hours
+      </span>
+      <h2 class="text-3xl sm:text-4xl font-bold mb-4 text-gray-900">
+        When We're <span class="text-primary">Open</span>
+      </h2>
+      <p class="text-base sm:text-lg text-gray-600 max-w-xl mx-auto">
+        Both branches follow the same schedule
+      </p>
+    </div>
+
+    <div class="max-w-md mx-auto">
+      <div class="rounded-2xl bg-white border border-gray-200 shadow-sm overflow-hidden">
+        <div class="divide-y divide-gray-100">
+          <div class="flex items-center justify-between px-6 py-4">
+            <span class="font-medium text-gray-900">Monday – Friday</span>
+            <span class="text-gray-600">6:00 AM – 10:00 PM</span>
+          </div>
+          <div class="flex items-center justify-between px-6 py-4">
+            <span class="font-medium text-gray-900">Saturday</span>
+            <span class="text-gray-600">6:00 AM – 2:00 PM</span>
+          </div>
+          <div class="flex items-center justify-between px-6 py-4">
+            <span class="font-medium text-gray-900">Sunday</span>
+            <span class="text-gray-400">Closed</span>
+          </div>
+        </div>
+      </div>
+
+      <p class="text-center text-sm text-gray-500 mt-5">
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          class="h-4 w-4 inline-block mr-1 -mt-0.5 text-primary"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+        >
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"
+          />
+        </svg>
+        Both Horsh Tabet &amp; Jal El Dib branches
+      </p>
+    </div>
+  </div>
+</section>
+
 <%!-- Final CTA Section --%>
 <section class="py-16 sm:py-20 md:py-24 bg-gradient-to-br from-neutral via-base-300 to-neutral relative overflow-hidden">
   <div class="absolute inset-0 bg-gradient-to-br from-primary/10 to-secondary/10"></div>

--- a/lib/gym_studio_web/live/links_live.ex
+++ b/lib/gym_studio_web/live/links_live.ex
@@ -54,6 +54,28 @@ defmodule GymStudioWeb.LinksLive do
 
       <%!-- Link Buttons --%>
       <div class="w-full max-w-sm space-y-4">
+        <%!-- Website link --%>
+        <a
+          href={~p"/"}
+          class="flex items-center justify-center gap-2 w-full py-3.5 px-6 rounded-full bg-white/10 backdrop-blur-sm border border-white/20 text-white font-semibold hover:bg-primary hover:border-primary hover:shadow-lg hover:shadow-primary/30 hover:scale-[1.02] transition-all duration-200"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            class="h-5 w-5"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              d="M21 12a9 9 0 01-9 9m9-9a9 9 0 00-9-9m9 9H3m9 9a9 9 0 01-9-9m9 9c1.657 0 3-4.03 3-9s-1.343-9-3-9m0 18c-1.657 0-3-4.03-3-9s1.343-9 3-9m-9 9a9 9 0 019-9"
+            />
+          </svg>
+          <span>Visit Our Website</span>
+        </a>
+
         <%!-- Location buttons --%>
         <%= for branch <- @branches do %>
           <a

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule GymStudio.MixProject do
   def project do
     [
       app: :gym_studio,
-      version: "0.8.4",
+      version: "0.8.5",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/gym_studio_web/controllers/page_controller_test.exs
+++ b/test/gym_studio_web/controllers/page_controller_test.exs
@@ -68,8 +68,8 @@ defmodule GymStudioWeb.PageControllerTest do
       assert response =~ "6:00 AM – 2:00 PM"
       assert response =~ "Sunday"
       assert response =~ "Closed"
-      # Both branches note
-      assert response =~ "Both Horsh Tabet &amp; Jal El Dib branches"
+      # All branches schedule
+      assert response =~ "All branches follow the same schedule"
     end
 
     test "GET / does not display DB-driven operating_hours", %{conn: conn} do

--- a/test/gym_studio_web/controllers/page_controller_test.exs
+++ b/test/gym_studio_web/controllers/page_controller_test.exs
@@ -55,12 +55,28 @@ defmodule GymStudioWeb.PageControllerTest do
       assert response =~ "place/33.9069"
     end
 
-    test "GET / does not display operating hours", %{conn: conn} do
+    test "GET / displays opening hours section", %{conn: conn} do
       conn = get(conn, ~p"/")
       response = html_response(conn, 200)
 
-      # Operating hours should not be shown for static branches
-      refute response =~ "Mon:"
+      # Opening hours section
+      assert response =~ "Opening Hours"
+      assert response =~ "When We're"
+      assert response =~ "Monday – Friday"
+      assert response =~ "6:00 AM – 10:00 PM"
+      assert response =~ "Saturday"
+      assert response =~ "6:00 AM – 2:00 PM"
+      assert response =~ "Sunday"
+      assert response =~ "Closed"
+      # Both branches note
+      assert response =~ "Both Horsh Tabet &amp; Jal El Dib branches"
+    end
+
+    test "GET / does not display DB-driven operating_hours", %{conn: conn} do
+      conn = get(conn, ~p"/")
+      response = html_response(conn, 200)
+
+      # The old DB-driven operating_hours field should not be rendered
       refute response =~ "operating_hours"
     end
 

--- a/test/gym_studio_web/live/links_live_test.exs
+++ b/test/gym_studio_web/live/links_live_test.exs
@@ -11,6 +11,8 @@ defmodule GymStudioWeb.LinksLiveTest do
       assert html =~ "React"
       # Slogan
       assert html =~ "Where Fitness Meets Personal Attention"
+      # Website link
+      assert html =~ "Visit Our Website"
       # Location buttons
       assert html =~ "📍"
       assert html =~ "Horsh Tabet"
@@ -45,6 +47,14 @@ defmodule GymStudioWeb.LinksLiveTest do
 
       assert html =~ "https://wa.me/96170379764"
       assert html =~ "https://wa.me/96171633970"
+    end
+
+    test "includes website link pointing to home page", %{conn: conn} do
+      {:ok, _lv, html} = live(conn, ~p"/links")
+
+      assert html =~ "Visit Our Website"
+      # The link should point to the root path
+      assert html =~ ~s(href="/")
     end
   end
 end


### PR DESCRIPTION
## Summary

Closes #125

### 1. Opening Hours on Landing Page (`home.html.heex`)
- Added a new "Opening Hours" section between Locations and the Final CTA
- **Mon–Fri:** 6:00 AM – 10:00 PM
- **Saturday:** 6:00 AM – 2:00 PM
- **Sunday:** Closed
- Note indicating both branches (Horsh Tabet & Jal El Dib) share the same hours
- Mobile-first DaisyUI + Tailwind design, consistent with existing site style

### 2. Website Link on Links Page (`links_live.ex`)
- Added "Visit Our Website" link button as the first item in the link list
- Points to root path (`/`)
- Styled consistently with existing linktree design (same hover effects, transitions, rounded-full)

### Test Updates
- Replaced "does not display operating hours" test with positive assertions for the new section
- Added test verifying the website link appears and points to `/`
- All 615 tests pass, 0 failures

### Screenshots
_N/A — static content changes only_