### PR TITLE
fix: dark mode invisible text in /links WhatsApp modal

### DIFF
--- a/lib/gym_studio_web/live/links_live.ex
+++ b/lib/gym_studio_web/live/links_live.ex
@@ -129,25 +129,25 @@ defmodule GymStudioWeb.LinksLive do
           <button class="btn btn-sm btn-circle btn-ghost absolute right-2 top-2">✕</button>
         </form>
         <h3 class="text-lg font-bold mb-1">Choose a Branch</h3>
-        <p class="text-sm text-gray-500 mb-5">Select which studio to contact on WhatsApp</p>
+        <p class="text-sm text-base-content/60 mb-5">Select which studio to contact on WhatsApp</p>
         <div class="grid gap-4">
           <%= for branch <- @branches do %>
             <a
               href={branch.whatsapp_url}
               target="_blank"
               rel="noopener noreferrer"
-              class="flex items-center gap-4 p-4 rounded-xl border border-gray-200 hover:border-primary/40 hover:shadow-md transition-all group"
+              class="flex items-center gap-4 p-4 rounded-xl border border-base-300 hover:border-primary/40 hover:shadow-md transition-all group"
             >
               <div class="w-12 h-12 rounded-full bg-primary/10 flex items-center justify-center flex-shrink-0 group-hover:bg-primary/20 transition-colors">
                 <Layouts.whatsapp_icon class="w-6 h-6 text-primary" />
               </div>
               <div class="flex-1 min-w-0">
-                <p class="font-semibold text-gray-900">{branch.name}</p>
-                <p class="text-sm text-gray-500 truncate">{branch.phone}</p>
+                <p class="font-semibold text-base-content">{branch.name}</p>
+                <p class="text-sm text-base-content/60 truncate">{branch.phone}</p>
               </div>
               <svg
                 xmlns="http://www.w3.org/2000/svg"
-                class="h-5 w-5 text-gray-400 group-hover:text-primary transition-colors flex-shrink-0"
+                class="h-5 w-5 text-base-content/40 group-hover:text-primary transition-colors flex-shrink-0"
                 viewBox="0 0 20 20"
                 fill="currentColor"
               >


### PR DESCRIPTION
Fixes #132

## Changes
Replaced hardcoded Tailwind color classes in the WhatsApp branch picker modal with DaisyUI semantic classes that adapt to dark mode:
- `text-gray-900` → `text-base-content`
- `text-gray-500` → `text-base-content/60`
- `border-gray-200` → `border-base-300`
- `text-gray-400` → `text-base-content/40`

All 642 tests pass.