### PR TITLE
feat: extract branch picker modal into reusable component + fix dark mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.8] - 2026-05-10
+
+### Changed
+- Extract WhatsApp branch picker modal into reusable `BranchPickerComponent` (#132)
+  - Shared component used by both `/links` page and homepage
+  - Removes 88 lines of duplicated modal markup
+
+### Fixed
+- Dark mode: invisible branch names and phone numbers in WhatsApp "Choose a Branch" modal (#132)
+  - Replaced hardcoded `gray-*` / `text-black` classes with DaisyUI semantic tokens (`text-base-content`, `text-base-content/60`, `border-base-300`)
+  - Text now correctly adapts to dark theme when OS/browser prefers dark color scheme
+
 ## [0.8.7] - 2026-05-03
 
 ### Added

--- a/lib/gym_studio_web/components/branch_picker_component.ex
+++ b/lib/gym_studio_web/components/branch_picker_component.ex
@@ -18,15 +18,16 @@ defmodule GymStudioWeb.BranchPickerComponent do
       `:phone` and `:address`. Displays `phone` if present, otherwise `address`.
   """
   attr :branches, :list, required: true
+  attr :id, :string, default: "whatsapp-modal"
 
   def branch_picker_modal(assigns) do
     ~H"""
-    <dialog id="whatsapp-modal" class="modal modal-bottom sm:modal-middle">
+    <dialog id={@id} class="modal modal-bottom sm:modal-middle" aria-labelledby={"#{@id}-title"}>
       <div class="modal-box">
         <form method="dialog">
           <button class="btn btn-sm btn-circle btn-ghost absolute right-2 top-2">✕</button>
         </form>
-        <h3 class="text-lg font-bold mb-1">Choose a Branch</h3>
+        <h3 id={"#{@id}-title"} class="text-lg font-bold mb-1">Choose a Branch</h3>
         <p class="text-sm text-base-content/60 mb-5">Select which studio to contact on WhatsApp</p>
         <div class="grid gap-4">
           <a
@@ -58,9 +59,12 @@ defmodule GymStudioWeb.BranchPickerComponent do
               />
             </svg>
           </a>
+          <p :if={Enum.empty?(@branches)} class="text-center text-base-content/60 py-4">
+            No branches available
+          </p>
         </div>
       </div>
-      <form method="dialog" class="modal-backdrop">
+      <form id={"#{@id}-backdrop"} method="dialog" class="modal-backdrop">
         <button>close</button>
       </form>
     </dialog>

--- a/lib/gym_studio_web/components/branch_picker_component.ex
+++ b/lib/gym_studio_web/components/branch_picker_component.ex
@@ -1,0 +1,69 @@
+defmodule GymStudioWeb.BranchPickerComponent do
+  @moduledoc """
+  Reusable WhatsApp branch picker modal.
+
+  Renders a `<dialog>` with branch cards that link to WhatsApp.
+  Uses DaisyUI semantic color classes for proper dark mode support.
+  """
+  use Phoenix.Component
+
+  alias GymStudioWeb.Layouts
+
+  @doc """
+  Renders a WhatsApp branch picker modal.
+
+  ## Assigns
+
+    * `branches` - list of maps with `:name`, `:whatsapp_url`, and optionally
+      `:phone` and `:address`. Displays `phone` if present, otherwise `address`.
+  """
+  attr :branches, :list, required: true
+
+  def branch_picker_modal(assigns) do
+    ~H"""
+    <dialog id="whatsapp-modal" class="modal modal-bottom sm:modal-middle">
+      <div class="modal-box">
+        <form method="dialog">
+          <button class="btn btn-sm btn-circle btn-ghost absolute right-2 top-2">✕</button>
+        </form>
+        <h3 class="text-lg font-bold mb-1">Choose a Branch</h3>
+        <p class="text-sm text-base-content/60 mb-5">Select which studio to contact on WhatsApp</p>
+        <div class="grid gap-4">
+          <a
+            :for={branch <- @branches}
+            href={branch.whatsapp_url}
+            target="_blank"
+            rel="noopener noreferrer"
+            class="flex items-center gap-4 p-4 rounded-xl border border-base-300 hover:border-primary/40 hover:shadow-md transition-all group"
+          >
+            <div class="w-12 h-12 rounded-full bg-primary/10 flex items-center justify-center flex-shrink-0 group-hover:bg-primary/20 transition-colors">
+              <Layouts.whatsapp_icon class="w-6 h-6 text-primary" />
+            </div>
+            <div class="flex-1 min-w-0">
+              <p class="font-semibold text-base-content">{branch.name}</p>
+              <p class="text-sm text-base-content/60 truncate">
+                {branch[:phone] || branch[:address]}
+              </p>
+            </div>
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              class="h-5 w-5 text-base-content/40 group-hover:text-primary transition-colors flex-shrink-0"
+              viewBox="0 0 20 20"
+              fill="currentColor"
+            >
+              <path
+                fill-rule="evenodd"
+                d="M10.293 3.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L14.586 11H3a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z"
+                clip-rule="evenodd"
+              />
+            </svg>
+          </a>
+        </div>
+      </div>
+      <form method="dialog" class="modal-backdrop">
+        <button>close</button>
+      </form>
+    </dialog>
+    """
+  end
+end

--- a/lib/gym_studio_web/controllers/page_html.ex
+++ b/lib/gym_studio_web/controllers/page_html.ex
@@ -6,6 +6,8 @@ defmodule GymStudioWeb.PageHTML do
   """
   use GymStudioWeb, :html
 
+  import GymStudioWeb.BranchPickerComponent
+
   embed_templates "page_html/*"
 
   # TODO(#92): Uncomment when operating hours are shown on landing page

--- a/lib/gym_studio_web/controllers/page_html/home.html.heex
+++ b/lib/gym_studio_web/controllers/page_html/home.html.heex
@@ -1,50 +1,6 @@
 <Layouts.flash_group flash={@flash} />
 
-<%!-- Branch Selector Modal --%>
-<dialog id="whatsapp-modal" class="modal modal-bottom sm:modal-middle">
-  <div class="modal-box">
-    <form method="dialog">
-      <button class="btn btn-sm btn-circle btn-ghost absolute right-2 top-2">✕</button>
-    </form>
-    <h3 class="text-lg font-bold mb-1">Choose a Branch</h3>
-    <p class="text-sm text-gray-500 mb-5">Select which studio to contact on WhatsApp</p>
-    <div class="grid gap-4">
-      <%= for branch <- @branches do %>
-        <a
-          href={branch.whatsapp_url}
-          target="_blank"
-          rel="noopener noreferrer"
-          class="flex items-center gap-4 p-4 rounded-xl border border-gray-200 hover:border-primary/40 hover:shadow-md transition-all group"
-        >
-          <div class="w-12 h-12 rounded-full bg-primary/10 flex items-center justify-center flex-shrink-0 group-hover:bg-primary/20 transition-colors">
-            <svg class="w-6 h-6 text-primary" viewBox="0 0 24 24" fill="currentColor">
-              <path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347m-5.421 7.403h-.004a9.87 9.87 0 01-5.031-1.378l-.361-.214-3.741.982.998-3.648-.235-.374a9.86 9.86 0 01-1.51-5.26c.001-5.45 4.436-9.884 9.888-9.884 2.64 0 5.122 1.03 6.988 2.898a9.825 9.825 0 012.893 6.994c-.003 5.45-4.437 9.884-9.885 9.884m8.413-18.297A11.815 11.815 0 0012.05 0C5.495 0 .16 5.335.157 11.892c0 2.096.547 4.142 1.588 5.945L.057 24l6.305-1.654a11.882 11.882 0 005.683 1.448h.005c6.554 0 11.89-5.335 11.893-11.893a11.821 11.821 0 00-3.48-8.413z" />
-            </svg>
-          </div>
-          <div class="flex-1 min-w-0">
-            <p class="font-semibold text-gray-900">{branch.name}</p>
-            <p class="text-sm text-gray-500 truncate">{branch.address}</p>
-          </div>
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            class="h-5 w-5 text-gray-400 group-hover:text-primary transition-colors flex-shrink-0"
-            viewBox="0 0 20 20"
-            fill="currentColor"
-          >
-            <path
-              fill-rule="evenodd"
-              d="M10.293 3.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L14.586 11H3a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z"
-              clip-rule="evenodd"
-            />
-          </svg>
-        </a>
-      <% end %>
-    </div>
-  </div>
-  <form method="dialog" class="modal-backdrop">
-    <button>close</button>
-  </form>
-</dialog>
+<.branch_picker_modal branches={@branches} />
 
 <%!-- Hero Section - Dark with optional background image --%>
 <section class="relative min-h-screen flex items-center justify-center overflow-hidden">

--- a/lib/gym_studio_web/live/links_live.ex
+++ b/lib/gym_studio_web/live/links_live.ex
@@ -5,6 +5,8 @@ defmodule GymStudioWeb.LinksLive do
   """
   use GymStudioWeb, :live_view
 
+  import GymStudioWeb.BranchPickerComponent
+
   @branches [
     %{
       name: "Horsh Tabet",
@@ -122,49 +124,7 @@ defmodule GymStudioWeb.LinksLive do
       </div>
     </div>
 
-    <%!-- WhatsApp Branch Picker Modal --%>
-    <dialog id="whatsapp-modal" class="modal modal-bottom sm:modal-middle">
-      <div class="modal-box">
-        <form method="dialog">
-          <button class="btn btn-sm btn-circle btn-ghost absolute right-2 top-2">✕</button>
-        </form>
-        <h3 class="text-lg font-bold mb-1">Choose a Branch</h3>
-        <p class="text-sm text-gray-500 mb-5">Select which studio to contact on WhatsApp</p>
-        <div class="grid gap-4">
-          <%= for branch <- @branches do %>
-            <a
-              href={branch.whatsapp_url}
-              target="_blank"
-              rel="noopener noreferrer"
-              class="flex items-center gap-4 p-4 rounded-xl border border-gray-200 hover:border-primary/40 hover:shadow-md transition-all group"
-            >
-              <div class="w-12 h-12 rounded-full bg-primary/10 flex items-center justify-center flex-shrink-0 group-hover:bg-primary/20 transition-colors">
-                <Layouts.whatsapp_icon class="w-6 h-6 text-primary" />
-              </div>
-              <div class="flex-1 min-w-0">
-                <p class="font-semibold text-gray-900">{branch.name}</p>
-                <p class="text-sm text-gray-500 truncate">{branch.phone}</p>
-              </div>
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                class="h-5 w-5 text-gray-400 group-hover:text-primary transition-colors flex-shrink-0"
-                viewBox="0 0 20 20"
-                fill="currentColor"
-              >
-                <path
-                  fill-rule="evenodd"
-                  d="M10.293 3.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L14.586 11H3a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z"
-                  clip-rule="evenodd"
-                />
-              </svg>
-            </a>
-          <% end %>
-        </div>
-      </div>
-      <form method="dialog" class="modal-backdrop">
-        <button>close</button>
-      </form>
-    </dialog>
+    <.branch_picker_modal branches={@branches} />
     """
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule GymStudio.MixProject do
   def project do
     [
       app: :gym_studio,
-      version: "0.8.7",
+      version: "0.8.8",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
Fixes #132 (also closes #124)

## Summary
The WhatsApp branch picker modal was copy-pasted across `/links` and `/` (homepage) with hardcoded `text-gray-*` classes that are invisible in dark mode. This PR extracts it into a reusable component and fixes the dark mode issue.

## Changes

**New file:**
- `lib/gym_studio_web/components/branch_picker_component.ex` — `branch_picker_modal/1` function component

**Modified:**
- `lib/gym_studio_web/live/links_live.ex` — replaced 42 lines of inline modal with `<.branch_picker_modal branches={@branches} />`
- `lib/gym_studio_web/controllers/page_html/home.html.heex` — replaced 46 lines of inline modal with `<.branch_picker_modal branches={@branches} />`
- `lib/gym_studio_web/controllers/page_html.ex` — added `import GymStudioWeb.BranchPickerComponent`

**Dark mode fixes (in the component):**
| Element | Before | After |
|---|---|---|
| Branch name | `text-gray-900` | `text-base-content` |
| Secondary text | `text-gray-500` | `text-base-content/60` |
| Card border | `border-gray-200` | `border-base-300` |
| Arrow icon | `text-gray-400` | `text-base-content/40` |

**Net result:** 75 additions, 88 deletions (-13 lines, less duplication)

## Testing
- ✅ 642 tests pass
- ✅ `mix format --check-formatted` clean
- ✅ `mix compile --warnings-as-errors` clean
- Manual dark mode verification needed before merge